### PR TITLE
0.9 devel

### DIFF
--- a/boost/network/protocol/http/server/async_connection.hpp
+++ b/boost/network/protocol/http/server/async_connection.hpp
@@ -148,8 +148,7 @@ namespace boost { namespace network { namespace http {
 
         ~async_connection() throw () {
             boost::system::error_code ignored;
-            socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ignored);
-            socket_.close(ignored);
+            socket_.shutdown(asio::ip::tcp::socket::shutdown_receive, ignored);
         }
 
         /** Function: template <class Range> set_headers(Range headers)

--- a/boost/network/protocol/http/server/sync_connection.hpp
+++ b/boost/network/protocol/http/server/sync_connection.hpp
@@ -247,8 +247,7 @@ namespace boost { namespace network { namespace http {
             if (!ec) {
                 using boost::asio::ip::tcp;
                 boost::system::error_code ignored_ec;
-                socket_.shutdown(tcp::socket::shutdown_both, ignored_ec);
-                socket_.close(ignored_ec);
+                socket_.shutdown(tcp::socket::shutdown_receive, ignored_ec);
             }
         }
 


### PR DESCRIPTION
fixed shutdown call for sync and async connections
removed close call - socket will be closed automatically whet out of scope
