### PR TITLE
Fix missing const qualifier in name(pair) and value(pair)

### DIFF
--- a/include/network/protocol/http/message/header/name.hpp
+++ b/include/network/protocol/http/message/header/name.hpp
@@ -14,7 +14,7 @@ namespace network {
 namespace http {
 
 template <class T1, class T2>
-T1 & 
+inline T1 const & 
 name(std::pair<T1,T2> const & p) {
   return p.first;
 }

--- a/include/network/protocol/http/message/header/value.hpp
+++ b/include/network/protocol/http/message/header/value.hpp
@@ -16,7 +16,7 @@ struct request_header;
 struct response_header;
 
 template <class T1, class T2>
-T1 & value(std::pair<T1,T2> const & p) {
+inline T1 const & value(std::pair<T1,T2> const & p) {
   return p.second;
 }
 


### PR DESCRIPTION
Fix missing `const` qualifier in return value of functions `name(const pair<T1,T2>&)` and `value(const pair<T1,T2>&)`

Otherwise construction like

``` cpp
static std::pair<std::string, std::string> headers[] = {
    {"connection", "keep-alive"},
    {"content-type", "text/xml; charset=\"UTF-8\""},
};
connection->set_headers(boost::make_iterator_range(headers, headers+2));
```

don't compile.
