### PR TITLE
Update boost/network/protocol/http/client/async_impl.hpp

### DIFF
--- a/boost/network/protocol/http/client/async_impl.hpp
+++ b/boost/network/protocol/http/client/async_impl.hpp
@@ -64,7 +64,9 @@ namespace boost { namespace network { namespace http {
         certificate_filename_(certificate_filename),
         verify_path_(verify_path)
       {
-      }
+         connection_base::resolver_strand_.reset(new
+    	            boost::asio::io_service::strand(service_));
+     }
 
       ~async_client() throw ()
       {


### PR DESCRIPTION
Properly initialize resolver_strand_ data member in async_client constructor that accepts an io_service.
