### PR TITLE
Fix build with clang on OS X

### DIFF
--- a/include/network/logging/logging.hpp
+++ b/include/network/logging/logging.hpp
@@ -63,12 +63,19 @@ public:
     m_text_stream << something;
     return *this;
   }
+  
+  template< typename TypeOfSomething >
+  inline log_record& operator<<( TypeOfSomething&& something )
+  {
+    return write( std::forward<TypeOfSomething>(something) );
+  }
 
   std::string message() const { return m_text_stream.str(); }
   const std::string& filename() const { return m_filename; }
   unsigned long line() const { return m_line; }
 
 private:
+
   // disable copy
   log_record( const log_record& ); // = delete;
   log_record& operator=( const log_record& ); // = delete;
@@ -77,12 +84,6 @@ private:
   std::string m_filename; // = UNKNOWN_FILE_NAME;
   unsigned long m_line; // = 0;
 };
-  
-template< typename TypeOfSomething >
-inline log_record& operator<<( log_record& log, TypeOfSomething&& something )
-{
-  return log.write( std::forward<TypeOfSomething>(something) );
-}
 
 }}
 


### PR DESCRIPTION
The NETWORK_MESSAGE macro causes an attempt to use the non-member operator<< with an rvalue being passed as a non-const lvalue reference. Clang correctly identifies this as an error. MSVC apparently accepts this if non-standard extensions are enabled (which is the default?).

My change simply moves the operator<< to be a member function of log_record which seemed to be the least problematic way to resolve the error.

Also, in case it's relevant:
clang++ --version
Apple clang version 4.1 (tags/Apple/clang-421.11.66) (based on LLVM 3.1svn)
Target: x86_64-apple-darwin12.2.0
Thread model: posix
