### PR TITLE
log_record now don't log on destruction, logging macro will.

### DIFF
--- a/include/network/detail/debug.hpp
+++ b/include/network/detail/debug.hpp
@@ -23,7 +23,7 @@
 
 #  include <network/logging/logging.hpp>
 #  ifndef NETWORK_MESSAGE
-#  define NETWORK_MESSAGE(msg) network::logging::log_record( __FILE__, __LINE__ ) << msg;
+#  define NETWORK_MESSAGE(msg) { network::logging::log( network::logging::log_record( __FILE__, __LINE__ ) << msg ); }
 #  endif
 
 #else

--- a/include/network/logging/logging.hpp
+++ b/include/network/logging/logging.hpp
@@ -51,12 +51,7 @@ public:
       , m_line( line )
   {
   }
-
-  ~log_record()
-  { 
-    log( *this );
-  }
-  
+    
   template< typename TypeOfSomething >
   log_record& write( TypeOfSomething&& something )
   {

--- a/libs/network/test/logging/logging_custom_handler.cpp
+++ b/libs/network/test/logging/logging_custom_handler.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(custom_log_handler_output) {
   const auto message = "At line " + std::to_string(line_num) + " we check the code.";
 
   set_log_record_handler( custom_log_handler );
-  log_record( file_name, line_num ) << "At line " << line_num << " we check the code.";
+  log( log_record( file_name, line_num ) << "At line " << line_num << " we check the code." );
 
   const auto result_output = log_output.str();
 

--- a/libs/network/test/logging/logging_log_record.cpp
+++ b/libs/network/test/logging/logging_log_record.cpp
@@ -10,6 +10,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <network/logging/logging.hpp>
+#define NETWORK_ENABLE_LOGGING
+#include <network/detail/debug.hpp>
 
 using namespace network::logging;
 
@@ -68,4 +70,9 @@ BOOST_AUTO_TEST_CASE(text_stream) {
 
 BOOST_AUTO_TEST_CASE(raw_log) {
   log( "This is a raw log." );
+}
+
+BOOST_AUTO_TEST_CASE(macro_log) {
+  NETWORK_MESSAGE( "This is a log through the macro." );
+  NETWORK_MESSAGE( "This is a log through the macro, with a stream! Num=" << 42  << " - OK!" );
 }


### PR DESCRIPTION
More consistent, and avoid a call to a throwing logging implementation in a destructor.
