### PR TITLE
Compilation fix in linearize_header (broken concept check)

### DIFF
--- a/include/network/protocol/http/algorithms/linearize.hpp
+++ b/include/network/protocol/http/algorithms/linearize.hpp
@@ -34,7 +34,7 @@ struct linearize_header {
   BOOST_CONCEPT_REQUIRES(
       ((Header<ValueType>)),
       (string_type)
-  ) operator()(ValueType & header) {
+  ) operator()(ValueType const & header) {
       typedef std::ostringstream output_stream;
       typedef constants consts;
       output_stream header_line;


### PR DESCRIPTION
This fixes broken concept check for `swap(h1, h2)` and
relaxes unneeded input restrictions for `linearize_header`.
