### PR TITLE
Provide source port as part of the request

### DIFF
--- a/boost/network/protocol/http/impl/request.hpp
+++ b/boost/network/protocol/http/impl/request.hpp
@@ -157,6 +157,7 @@ namespace http {
         typedef vector_type headers_container_type;
         typedef boost::uint16_t port_type;
         mutable string_type source;
+        mutable port_type source_port;
         mutable string_type method;
         mutable string_type destination;
         mutable boost::uint8_t http_version_major;
@@ -168,6 +169,7 @@ namespace http {
             using std::swap;
             swap(method, r.method);
             swap(source, r.source);
+            swap(source_port, r.source_port);
             swap(destination, r.destination);
             swap(http_version_major, r.http_version_major);
             swap(http_version_minor, r.http_version_minor);

--- a/boost/network/protocol/http/server/sync_connection.hpp
+++ b/boost/network/protocol/http/server/sync_connection.hpp
@@ -79,6 +79,7 @@ namespace boost { namespace network { namespace http {
         void handle_read_headers(boost::system::error_code const &ec, size_t bytes_transferred) {
             if (!ec) {
                 request_.source = socket_.remote_endpoint().address().to_string();
+                request_.source_port = socket_.remote_endpoint().port();
                 boost::tribool done;
                 buffer_type::iterator new_start;
                 tie(done,new_start) = parser_.parse_headers(request_, buffer_.data(), buffer_.data() + bytes_transferred);

--- a/libs/network/example/http/hello_world_server.cpp
+++ b/libs/network/example/http/hello_world_server.cpp
@@ -29,8 +29,9 @@ struct hello_world {
     void operator() (server::request const &request,
                      server::response &response) {
         server::string_type ip = source(request);
+        unsigned int port = request.source_port;
         std::ostringstream data;
-        data << "Hello, " << ip << "!";
+        data << "Hello, " << ip << ':' << port << '!';
         response = server::response::stock_reply(
             server::response::ok, data.str());
     }


### PR DESCRIPTION
This might be a naive implementation. For example, I couldn't figure out how to mirror the `source(request)` behavior in the "hello world" example (e.g. how do I allow for `source_port(request)` instead of only `request.source_port`?).

Also, it appears that `destination` is not symmetric to `source`. I expected to see an IP in `request::destination`, but I saw the URL path instead. Thus, I did not add a `destination_port` member.
