### PR TITLE
Amended `git submodule` instructions in the README (fixes #220).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ submodules:
 ::
 
     $ cd ~/cpp-netlib
+    $ git submodule init
     $ git submodule update
 
 Building with CMake


### PR DESCRIPTION
For a fresh checkout, the README's instructions for `git submodule update` don't suffice (it does nothing at all). One must first perform an `git submodule init` before the `git submodule update`, as follows:

```
$ git submodule init
Submodule 'deps/gmock' (git://github.com/cpp-netlib/gmock) registered for path 'deps/gmock'
Submodule 'deps/gtest' (git://github.com/cpp-netlib/gtest) registered for path 'deps/gtest'
Submodule 'uri' (git://github.com/cpp-netlib/uri) registered for path 'uri'

$ git submodule update
Cloning into 'deps/gmock'...
...
Submodule path 'deps/gmock': checked out '6b1759c3816d574bddde3e1725c51a811c8870e7'
Cloning into 'deps/gtest'...
...
Submodule path 'deps/gtest': checked out 'a6772271f71672e889776bfe49ec4efd9da036df'
Cloning into 'uri'...
...
Submodule path 'uri': checked out 'e3ed456dbec947765018b1dde9ede787bad91814'
```

(This is with Git version 1.8.0.2.)

Please amend the README instructions to mention `git submodule init`.
