### PR TITLE
Use string_ref compare method instead of an undefined equality operator between string_ref and char*

### DIFF
--- a/http/src/network/protocol/http/message/wrappers/port.ipp
+++ b/http/src/network/protocol/http/message/wrappers/port.ipp
@@ -22,9 +22,9 @@ port_wrapper::operator boost:: uint16_t() const {
   if (!optional_port) {
     auto scheme_ = uri_.scheme();
     assert(scheme_);
-    if (*scheme_ == "http") {
+    if (scheme_->compare("http") == 0) {
       return 80u;
-    } else if (*scheme_ == "https") {
+    } else if (scheme_->compare("https") == 0) {
       return 443u;
     }
   }


### PR DESCRIPTION
This involve some overhead (implicit conversations from char\* to string, and from string to string_ref)
