### PR TITLE
fix chunked client async_normal.hpp

### DIFF
--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -452,7 +452,7 @@ namespace boost { namespace network { namespace http { namespace impl {
                 break;
             if (len <= body_string.end() - iter) {
                 body.insert(body.end(), iter, iter + len);
-                std::advance(iter, len);
+                std::advance(iter, len+2);
             }
             begin = iter;
         }


### PR DESCRIPTION
Chunked response for clients.
If response has
...<chunk>CLRF<hex>CLRF<data>...
We need to skip past chunk-data ending CLRF, otherwise we find it again and on next iteration begin==iter

It might not be the right fix for all cases, but it works for a local case with no chunk-extensions between chunk blocks.
