### PR TITLE
- copy test data to build directory instead of assuming in-place build

### DIFF
--- a/libs/mime/test/CMakeLists.txt
+++ b/libs/mime/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(${CPP-NETLIB_SOURCE_DIR})
 find_package ( Boost 1.41.0 COMPONENTS unit_test_framework )
+file ( COPY TestMessages DESTINATION ${CMAKE_CURRENT_BINARY_DIR} )
 
 option (BOOST_DYN_LINK
   "Build the project using dynamic linking for the boost test libs"


### PR DESCRIPTION
Fixes #283. However the build is broken for the current tip of this branch so I was unable to test. Works against 0.10.1 release, though.
