### PR TITLE
add CMake definitions to build and install shared libraries and headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ find_package( OpenSSL )
 find_package( Threads )
 set(CMAKE_VERBOSE_MAKEFILE true)
 
+set(BUILD_SHARED_LIBS ON)
+set(CPPNETLIB_VERSION_MAJOR 0) # MUST bump this whenever we make ABI-incompatible changes
+set(CPPNETLIB_VERSION_MINOR 10)
+set(CPPNETLIB_VERSION_PATCH 1)
+set(CPPNETLIB_VERSION_STRING ${CPPNETLIB_VERSION_MAJOR}.${CPPNETLIB_VERSION_MINOR}.${CPPNETLIB_VERSION_PATCH})
+
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     add_definitions(-DBOOST_NETWORK_DEBUG)
 endif()
@@ -60,3 +66,5 @@ if (MSVC)
 endif()
 
 enable_testing()
+
+install(DIRECTORY boost DESTINATION "include")

--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -10,9 +10,18 @@ include_directories(${CPP-NETLIB_SOURCE_DIR})
 
 set(CPP-NETLIB_URI_SRCS uri/uri.cpp uri/schemes.cpp)
 add_library(cppnetlib-uri ${CPP-NETLIB_URI_SRCS})
+set_target_properties(cppnetlib-uri
+  PROPERTIES VERSION ${CPPNETLIB_VERSION_STRING} SOVERSION ${CPPNETLIB_VERSION_MAJOR})
+install(TARGETS cppnetlib-uri DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
 
 set(CPP-NETLIB_HTTP_SERVER_SRCS server_request_parsers_impl.cpp)
 add_library(cppnetlib-server-parsers ${CPP-NETLIB_HTTP_SERVER_SRCS})
+set_target_properties(cppnetlib-server-parsers
+  PROPERTIES VERSION ${CPPNETLIB_VERSION_STRING} SOVERSION ${CPPNETLIB_VERSION_MAJOR})
+install(TARGETS cppnetlib-server-parsers DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
 
 set(CPP-NETLIB_HTTP_CLIENT_SRCS client.cpp)
 add_library(cppnetlib-client-connections ${CPP-NETLIB_HTTP_CLIENT_SRCS})
+set_target_properties(cppnetlib-client-connections
+  PROPERTIES VERSION ${CPPNETLIB_VERSION_STRING} SOVERSION ${CPPNETLIB_VERSION_MAJOR})
+install(TARGETS cppnetlib-client-connections DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})


### PR DESCRIPTION
This is a start of an install process. It installs the core functionality of this package, i.e. shared libraries and headers, but it does not yet install documentation and other metadata.
