### PR TITLE
directly use GNU install dirs rather than hard-coding matching ones

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,4 +67,5 @@ endif()
 
 enable_testing()
 
-install(DIRECTORY boost DESTINATION "include")
+include(GNUInstallDirs)
+install(DIRECTORY boost DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -12,16 +12,16 @@ set(CPP-NETLIB_URI_SRCS uri/uri.cpp uri/schemes.cpp)
 add_library(cppnetlib-uri ${CPP-NETLIB_URI_SRCS})
 set_target_properties(cppnetlib-uri
   PROPERTIES VERSION ${CPPNETLIB_VERSION_STRING} SOVERSION ${CPPNETLIB_VERSION_MAJOR})
-install(TARGETS cppnetlib-uri DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
+install(TARGETS cppnetlib-uri DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 set(CPP-NETLIB_HTTP_SERVER_SRCS server_request_parsers_impl.cpp)
 add_library(cppnetlib-server-parsers ${CPP-NETLIB_HTTP_SERVER_SRCS})
 set_target_properties(cppnetlib-server-parsers
   PROPERTIES VERSION ${CPPNETLIB_VERSION_STRING} SOVERSION ${CPPNETLIB_VERSION_MAJOR})
-install(TARGETS cppnetlib-server-parsers DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
+install(TARGETS cppnetlib-server-parsers DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 set(CPP-NETLIB_HTTP_CLIENT_SRCS client.cpp)
 add_library(cppnetlib-client-connections ${CPP-NETLIB_HTTP_CLIENT_SRCS})
 set_target_properties(cppnetlib-client-connections
   PROPERTIES VERSION ${CPPNETLIB_VERSION_STRING} SOVERSION ${CPPNETLIB_VERSION_MAJOR})
-install(TARGETS cppnetlib-client-connections DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
+install(TARGETS cppnetlib-client-connections DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
It turns out that CMake has a bunch of macros that conveniently define variables that fit the GNU standards for installation. This is available on all platforms including windows, but I have not tested it directly on that platform.
