### PR TITLE
fixed read timeout in chucked content response for sync keep-alive client

### DIFF
--- a/boost/network/protocol/http/client/connection/sync_base.hpp
+++ b/boost/network/protocol/http/client/connection/sync_base.hpp
@@ -169,11 +169,11 @@ struct sync_connection_base_impl {
             bool stopping_inner = false;
             do {
               if (response_buffer.size() < (chunk_size+2)){
-                std::size_t toRead = (chunk_size+2) - response_buffer.size();
+                std::size_t bytes_to_read = (chunk_size+2) - response_buffer.size();
                 std::size_t chunk_bytes_read =
                     read(socket_,
                          response_buffer,
-                         boost::asio::transfer_at_least(toRead),
+                         boost::asio::transfer_at_least(bytes_to_read),
                          error);
                 if (chunk_bytes_read == 0) {
                   if (error != boost::asio::error::eof)


### PR DESCRIPTION
After some testing, i noticed the keep-alive sync http client waited about 20 seconds before returning a trivial content (about 111 bytes). I tracked it down to this fix. The problem was that boost::asio::read is called, even if there are enough bytes in the current stream buffer. This causes read to wait until timeout (which on my windows platform was 20 secs, apparently). The fix is to not read if there are enough bytes in the current stream buffer. I am also counting 2 extra bytes for "\r\n" that comes after each chunk.
