### PR TITLE
Getting started documentation

### DIFF
--- a/libs/network/doc/getting_started.rst
+++ b/libs/network/doc/getting_started.rst
@@ -159,7 +159,7 @@ Once the build has completed, you can now run the test suite by issuing::
 
     $ make test
 
-You can install :mod:`cpp-netlib` by issueing::
+You can install :mod:`cpp-netlib` by issuing::
 
     $ sudo make install
 


### PR DESCRIPTION
- Additions that show how to use cpp-netlib as a dependency from a CMake project.
- Moved part of note about about generated static libraries from Windows build section to Linux section.  The Linux section contains the part of the note about the static libraries generated by gcc; the Windows section contains the part of the note about the static libraries generated by Visual Studio.
- **NOT included in PR**: html documents that sphinx generates.

-- Kasper van den Berg
