### PR TITLE
cv-qualifier should be removed before checking the Header concept

### DIFF
--- a/boost/network/protocol/http/algorithms/linearize.hpp
+++ b/boost/network/protocol/http/algorithms/linearize.hpp
@@ -35,7 +35,7 @@ namespace boost { namespace network { namespace http {
 
         template <class ValueType>
         BOOST_CONCEPT_REQUIRES(
-            ((Header<ValueType>)),
+            ((Header<typename boost::remove_cv<ValueType>::type>)),
             (string_type)
         ) operator()(ValueType & header) {
             typedef typename ostringstream<Tag>::type output_stream;


### PR DESCRIPTION
C++11 allows this kind of construction:

```
connection->set_status(Connection::bad_request);
const auto size_to_send = std::to_string(reason.size());
auto headers = { Header{"Content-Length", size_to_send} };
auto range = boost::make_iterator_range(headers);
connection->set_headers(range);
connection->write(reason);
```

But in the case of an initializer_list, elements are const, then the actual
type tested is "const ValueType" instead of "ValueType".
