### PR TITLE
Examples stop io_service.

### DIFF
--- a/libs/network/doc/examples/http/hello_world_client.rst
+++ b/libs/network/doc/examples/http/hello_world_client.rst
@@ -17,6 +17,8 @@ server that we created earlier. This really simple client will look like this:
 .. code-block:: c++
 
     #include <boost/network/protocol/http/client.hpp>
+    #include <boost/asio/io_service.hpp>
+    #include <boost/shared_ptr.hpp>
     #include <string>
     #include <sstream>
     #include <iostream>
@@ -30,7 +32,9 @@ server that we created earlier. This really simple client will look like this:
         }
 
         try {
-            http::client client;
+            boost::shared_ptr<asio::io_service> io_service = boost::make_shared<asio::io_service>();
+            http::client client(http::client::options()
+                    .io_service(io_service));
             std::ostringstream url;
             url << "http://" << argv[1] << ":" << argv[2] << "/";
             http::client::request request(url.str());
@@ -39,8 +43,10 @@ server that we created earlier. This really simple client will look like this:
             std::cout << body(response) << std::endl;
         } catch (std::exception & e) {
             std::cerr << e.what() << std::endl;
+            io_service->stop();
             return 1;
         }
+        io_service->stop();
         return 0;
     }
 

--- a/libs/network/doc/examples/http/http_client.rst
+++ b/libs/network/doc/examples/http/http_client.rst
@@ -18,6 +18,8 @@ Without further ado, the code to do this is as follows:
 .. code-block:: c++
 
     #include <boost/network/protocol/http/client.hpp>
+    #include <boost/asio/io_service.hpp>
+    #include <boost/shared_ptr.hpp>
     #include <iostream>
 
     int main(int argc, char *argv[]) {
@@ -28,7 +30,9 @@ Without further ado, the code to do this is as follows:
     	    return 1;
         }
 
-        http::client client;
+        boost::shared_ptr<asio::io_service> io_service = boost::make_shared<asio::io_service>();
+        http::client client(http::client::options()
+                .io_service(io_service));
         http::client::request request(argv[1]);
 	request << header("Connection", "close");
 	http::client::response response = client.get(request);

--- a/libs/network/example/http_client.cpp
+++ b/libs/network/example/http_client.cpp
@@ -11,6 +11,8 @@
 */
 #include <boost/program_options.hpp>
 #include <boost/network/protocol/http.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/shared_ptr.hpp>
 #include <string>
 #include <utility>
 #include <iostream>
@@ -62,8 +64,11 @@ int main(int argc, char * argv[]) {
     http_client::string_type destination_ = host(request);
 
     request << ::boost::network::header("Connection", "close");
-    http_client::options client_options;
-    http_client client(client_options.follow_redirects(true));
+    boost::shared_ptr<asio::io_service> io_service = boost::make_shared<asio::io_service>();
+    http_client::options client_options
+        .io_service(io_service)
+        .follow_redirects(true);
+    http_client client(client_options);
     http_client::response response = client.get(request);
 
     if (show_headers) {
@@ -77,6 +82,8 @@ int main(int argc, char * argv[]) {
 
     body_range<http_client::response>::type body_ = body(response).range();
     boost::copy(body_, std::ostream_iterator<char_<http_client::request::tag>::type>(std::cout));
+
+    io_service->stop();
     return EXIT_SUCCESS;
 }
 //]

--- a/libs/network/example/http_client1.cpp
+++ b/libs/network/example/http_client1.cpp
@@ -5,19 +5,25 @@
 
 
 #include <boost/network/protocol/http/client.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/shared_ptr.hpp>
 #include <iostream>
 
 int main(int argc, char * argv[]) {
     using namespace boost::network;
+    namespace asio = boost::asio;
 
     if (argc != 2) { std::cout << "Usage: " << argv[0] << " <url>" << std::endl; return 1; }
 
-    http::client client;
+    boost::shared_ptr<asio::io_service> io_service = boost::make_shared<asio::io_service>();
+    http::client client(http::client::options()
+            .io_service(io_service));
     http::client::request request(argv[1]);
     request << header("Connection", "close");
     http::client::response response = client.get(request);
     std::cout << body(response) << std::endl;
 
+    io_service->stop();
     return 0;
 }
 


### PR DESCRIPTION
The example programs did not finish; by supplying and asio::io_service and invoking 'stop()' on that services the examples should finish correctly.

What to do with the documentation?
Currently I only updated the example code in the documentation.
- On one hand, users might be confused about the `client_options`, the `shared_ptr<asio::io_service>`, etc., thus I should describe their use; and
- one the other hand, `client_options` and `shared_ptr<asio::io_service>` distract from the simple proces of build-request, create client, and process response.

Not fixed:
- hello_world_client.rst and http_client.rst appear to be duplicates, perhaps to remove one of them.
- same issue for http_client.cpp and http_client1.cpp

~~ Kasper van den Berg
