### PR TITLE
Added a client certificate support.

### DIFF
--- a/boost/network/protocol/http/client/async_impl.hpp
+++ b/boost/network/protocol/http/client/async_impl.hpp
@@ -40,7 +40,9 @@ struct async_client
                bool always_verify_peer,
                boost::shared_ptr<boost::asio::io_service> service,
                optional<string_type> const& certificate_filename,
-               optional<string_type> const& verify_path)
+               optional<string_type> const& verify_path,
+               optional<string_type> const& certificate_file,
+               optional<string_type> const& private_key_file)
       : connection_base(cache_resolved, follow_redirect),
         service_ptr(service.get()
                         ? service
@@ -50,6 +52,8 @@ struct async_client
         sentinel_(new boost::asio::io_service::work(service_)),
         certificate_filename_(certificate_filename),
         verify_path_(verify_path),
+        certificate_file_(certificate_file),
+        private_key_file_(private_key_file),
         always_verify_peer_(always_verify_peer) {
     connection_base::resolver_strand_.reset(
         new boost::asio::io_service::strand(service_));
@@ -71,8 +75,9 @@ struct async_client
       body_generator_function_type generator) {
     typename connection_base::connection_ptr connection_;
     connection_ = connection_base::get_connection(
-        resolver_, request_, always_verify_peer_, certificate_filename_,
-        verify_path_);
+        resolver_, request_, always_verify_peer_,
+        certificate_filename_, verify_path_,
+        certificate_file_, private_key_file_);
     return connection_->send_request(method, request_, get_body, callback,
                                      generator);
   }
@@ -82,7 +87,10 @@ struct async_client
   resolver_type resolver_;
   boost::shared_ptr<boost::asio::io_service::work> sentinel_;
   boost::shared_ptr<boost::thread> lifetime_thread_;
-  optional<string_type> certificate_filename_, verify_path_;
+  optional<string_type> certificate_filename_;
+  optional<string_type> verify_path_;
+  optional<string_type> certificate_file_;
+  optional<string_type> private_key_file_;
   bool always_verify_peer_;
 };
 }  // namespace impl

--- a/boost/network/protocol/http/client/connection/async_base.hpp
+++ b/boost/network/protocol/http/client/connection/async_base.hpp
@@ -40,7 +40,9 @@ namespace boost { namespace network { namespace http { namespace impl {
         bool always_verify_peer,
         bool https,
         optional<string_type> certificate_filename=optional<string_type>(),
-        optional<string_type> const & verify_path=optional<string_type>()) {
+        optional<string_type> const & verify_path=optional<string_type>(),
+        optional<string_type> certificate_file=optional<string_type>(),
+        optional<string_type> private_key_file=optional<string_type>()) {
       typedef http_async_connection<Tag,version_major,version_minor>
           async_connection;
       typedef typename delegate_factory<Tag>::type delegate_factory_type;
@@ -55,7 +57,9 @@ namespace boost { namespace network { namespace http { namespace impl {
                   https,
                   always_verify_peer,
                   certificate_filename,
-                  verify_path)));
+                  verify_path,
+                  certificate_file,
+                  private_key_file)));
       BOOST_ASSERT(temp.get() != 0);
       return temp;
     }

--- a/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
+++ b/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
@@ -32,14 +32,18 @@ struct connection_delegate_factory {
       bool https,
       bool always_verify_peer,
       optional<string_type> certificate_filename,
-      optional<string_type> verify_path) {
+      optional<string_type> verify_path,
+      optional<string_type> certificate_file,
+      optional<string_type> private_key_file) {
     connection_delegate_ptr delegate;
     if (https) {
 #ifdef BOOST_NETWORK_ENABLE_HTTPS
       delegate.reset(new ssl_delegate(service,
                                       always_verify_peer,
                                       certificate_filename,
-                                      verify_path));
+                                      verify_path,
+                                      certificate_file,
+                                      private_key_file));
 #else
       BOOST_THROW_EXCEPTION(std::runtime_error("HTTPS not supported."));
 #endif /* BOOST_NETWORK_ENABLE_HTTPS */

--- a/boost/network/protocol/http/client/connection/ssl_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.hpp
@@ -24,7 +24,9 @@ struct ssl_delegate : connection_delegate,
                       enable_shared_from_this<ssl_delegate> {
   ssl_delegate(asio::io_service &service, bool always_verify_peer,
                optional<std::string> certificate_filename,
-               optional<std::string> verify_path);
+               optional<std::string> verify_path,
+               optional<std::string> certificate_file,
+               optional<std::string> private_key_file);
 
   virtual void connect(asio::ip::tcp::endpoint &endpoint,
                        function<void(system::error_code const &)> handler);
@@ -38,7 +40,10 @@ struct ssl_delegate : connection_delegate,
 
  private:
   asio::io_service &service_;
-  optional<std::string> certificate_filename_, verify_path_;
+  optional<std::string> certificate_filename_;
+  optional<std::string> verify_path_;
+  optional<std::string> certificate_file_;
+  optional<std::string> private_key_file_;
   scoped_ptr<asio::ssl::context> context_;
   scoped_ptr<asio::ssl::stream<asio::ip::tcp::socket> > socket_;
   bool always_verify_peer_;

--- a/boost/network/protocol/http/client/connection/ssl_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.ipp
@@ -14,10 +14,14 @@
 boost::network::http::impl::ssl_delegate::ssl_delegate(
     asio::io_service &service, bool always_verify_peer,
     optional<std::string> certificate_filename,
-    optional<std::string> verify_path)
+    optional<std::string> verify_path,
+    optional<std::string> certificate_file,
+    optional<std::string> private_key_file)
     : service_(service),
       certificate_filename_(certificate_filename),
       verify_path_(verify_path),
+      certificate_file_(certificate_file),
+      private_key_file_(private_key_file),
       always_verify_peer_(always_verify_peer) {}
 
 void boost::network::http::impl::ssl_delegate::connect(
@@ -36,6 +40,12 @@ void boost::network::http::impl::ssl_delegate::connect(
     else
       context_->set_verify_mode(asio::ssl::context::verify_none);
   }
+  if (certificate_file_)
+    context_->use_certificate_file(
+      *certificate_file_, boost::asio::ssl::context::pem);
+  if (private_key_file_)
+    context_->use_private_key_file(
+      *private_key_file_, boost::asio::ssl::context::pem);
   socket_.reset(
       new asio::ssl::stream<asio::ip::tcp::socket>(service_, *context_));
   socket_->lowest_layer().async_connect(

--- a/boost/network/protocol/http/client/connection/sync_base.hpp
+++ b/boost/network/protocol/http/client/connection/sync_base.hpp
@@ -240,16 +240,22 @@ struct sync_connection_base {
   static sync_connection_base<Tag, version_major, version_minor>*
   new_connection(resolver_type& resolver, resolver_function_type resolve,
                  bool https, bool always_verify_peer,
-                 optional<string_type> const& cert_filename =
+                 optional<string_type> const& certificate_filename =
                      optional<string_type>(),
                  optional<string_type> const& verify_path =
+                     optional<string_type>(),
+                 optional<string_type> const& certificate_file =
+                     optional<string_type>(),
+                 optional<string_type> const& private_key_file =
                      optional<string_type>()) {
     if (https) {
 #ifdef BOOST_NETWORK_ENABLE_HTTPS
       return dynamic_cast<
           sync_connection_base<Tag, version_major, version_minor>*>(
           new https_sync_connection<Tag, version_major, version_minor>(
-              resolver, resolve, cert_filename, verify_path));
+              resolver, resolve,
+              certificate_filename, verify_path,
+              certificate_file, private_key_file));
 #else
       throw std::runtime_error("HTTPS not supported.");
 #endif

--- a/boost/network/protocol/http/client/connection/sync_ssl.hpp
+++ b/boost/network/protocol/http/client/connection/sync_ssl.hpp
@@ -51,6 +51,10 @@ struct https_sync_connection
                         optional<string_type> const& certificate_filename =
                             optional<string_type>(),
                         optional<string_type> const& verify_path =
+                            optional<string_type>(),
+                        optional<string_type> const& certificate_file =
+                            optional<string_type>(),
+                        optional<string_type> const& private_key_file =
                             optional<string_type>())
       : connection_base(),
         resolver_(resolver),
@@ -71,6 +75,12 @@ struct https_sync_connection
       else
         context_.set_verify_mode(boost::asio::ssl::context_base::verify_none);
     }
+    if (certificate_file)
+      context_.use_certificate_file(
+        *certificate_file, boost::asio::ssl::context::pem);
+    if (private_key_file)
+      context_.use_private_key_file(
+        *private_key_file, boost::asio::ssl::context::pem);
   }
 
   void init_socket(string_type const& hostname, string_type const& port) {

--- a/boost/network/protocol/http/client/facade.hpp
+++ b/boost/network/protocol/http/client/facade.hpp
@@ -170,6 +170,8 @@ struct basic_client_facade {
                                options.always_verify_peer(),
                                options.openssl_certificate(),
                                options.openssl_verify_path(),
+                               options.openssl_certificate_file(),
+                               options.openssl_private_key_file(),
                                options.io_service()));
   }
 };

--- a/boost/network/protocol/http/client/options.hpp
+++ b/boost/network/protocol/http/client/options.hpp
@@ -25,6 +25,8 @@ struct client_options {
         follow_redirects_(false),
         openssl_certificate_(),
         openssl_verify_path_(),
+        openssl_certificate_file_(),
+        openssl_private_key_file_(),
         io_service_(),
         always_verify_peer_(false) {}
 
@@ -33,6 +35,8 @@ struct client_options {
         follow_redirects_(other.follow_redirects_),
         openssl_certificate_(other.openssl_certificate_),
         openssl_verify_path_(other.openssl_verify_path_),
+        openssl_certificate_file_(other.openssl_certificate_file_),
+        openssl_private_key_file_(other.openssl_private_key_file_),
         io_service_(other.io_service_),
         always_verify_peer_(other.always_verify_peer_) {}
 
@@ -47,6 +51,8 @@ struct client_options {
     swap(follow_redirects_, other.follow_redirects_);
     swap(openssl_certificate_, other.openssl_certificate_);
     swap(openssl_verify_path_, other.openssl_verify_path_);
+    swap(openssl_certificate_file_, other.openssl_certificate_file_);
+    swap(openssl_private_key_file_, other.openssl_private_key_file_);
     swap(io_service_, other.io_service_);
     swap(always_verify_peer_, other.always_verify_peer_);
   }
@@ -71,6 +77,16 @@ struct client_options {
     return *this;
   }
 
+  client_options& openssl_certificate_file(string_type const& v) {
+    openssl_certificate_file_ = v;
+    return *this;
+  }
+
+  client_options& openssl_private_key_file(string_type const& v) {
+    openssl_private_key_file_ = v;
+    return *this;
+  }
+
   client_options& io_service(boost::shared_ptr<boost::asio::io_service> v) {
     io_service_ = v;
     return *this;
@@ -88,6 +104,14 @@ struct client_options {
     return openssl_verify_path_;
   }
 
+  boost::optional<string_type> openssl_certificate_file() const {
+    return openssl_certificate_file_;
+  }
+
+  boost::optional<string_type> openssl_private_key_file() const {
+    return openssl_private_key_file_;
+  }
+
   boost::shared_ptr<boost::asio::io_service> io_service() const {
     return io_service_;
   }
@@ -99,6 +123,8 @@ struct client_options {
   bool follow_redirects_;
   boost::optional<string_type> openssl_certificate_;
   boost::optional<string_type> openssl_verify_path_;
+  boost::optional<string_type> openssl_certificate_file_;
+  boost::optional<string_type> openssl_private_key_file_;
   boost::shared_ptr<boost::asio::io_service> io_service_;
   bool always_verify_peer_;
 };

--- a/boost/network/protocol/http/client/pimpl.hpp
+++ b/boost/network/protocol/http/client/pimpl.hpp
@@ -69,9 +69,12 @@ struct basic_client_impl
                     bool always_verify_peer,
                     optional<string_type> const& certificate_filename,
                     optional<string_type> const& verify_path,
+                    optional<string_type> const& certificate_file,
+                    optional<string_type> const& private_key_file,
                     boost::shared_ptr<boost::asio::io_service> service)
       : base_type(cache_resolved, follow_redirect, always_verify_peer, service,
-                  certificate_filename, verify_path) {}
+                  certificate_filename, verify_path,
+                  certificate_file, private_key_file) {}
 
   ~basic_client_impl() {}
 };

--- a/boost/network/protocol/http/client/sync_impl.hpp
+++ b/boost/network/protocol/http/client/sync_impl.hpp
@@ -40,23 +40,32 @@ struct sync_client
   boost::shared_ptr<boost::asio::io_service> service_ptr;
   boost::asio::io_service& service_;
   resolver_type resolver_;
-  optional<string_type> certificate_file, verify_path;
+  optional<string_type> certificate_filename_;
+  optional<string_type> verify_path_;
+  optional<string_type> certificate_file_;
+  optional<string_type> private_key_file_;
   bool always_verify_peer_;
 
   sync_client(bool cache_resolved, bool follow_redirect,
               bool always_verify_peer,
               boost::shared_ptr<boost::asio::io_service> service,
-              optional<string_type> const& certificate_file =
+              optional<string_type> const& certificate_filename =
                   optional<string_type>(),
               optional<string_type> const& verify_path =
+                  optional<string_type>(),
+              optional<string_type> const& certificate_file =
+                  optional<string_type>(),
+              optional<string_type> const& private_key_file =
                   optional<string_type>())
       : connection_base(cache_resolved, follow_redirect),
         service_ptr(service.get() ? service
                                   : make_shared<boost::asio::io_service>()),
         service_(*service_ptr),
         resolver_(service_),
-        certificate_file(certificate_file),
-        verify_path(verify_path),
+        certificate_filename_(certificate_filename),
+        verify_path_(verify_path),
+        certificate_file_(certificate_file),
+        private_key_file_(private_key_file),
         always_verify_peer_(always_verify_peer) {}
 
   ~sync_client() {
@@ -70,7 +79,9 @@ struct sync_client
                                        body_generator_function_type generator) {
     typename connection_base::connection_ptr connection_;
     connection_ = connection_base::get_connection(
-        resolver_, request_, certificate_file, verify_path);
+        resolver_, request_,
+        certificate_filename_, verify_path_,
+        certificate_file_, private_key_file_);
     return connection_->send_request(method, request_, get_body, callback,
                                      generator);
   }

--- a/boost/network/protocol/http/policies/async_connection.hpp
+++ b/boost/network/protocol/http/policies/async_connection.hpp
@@ -40,12 +40,15 @@ struct async_connection_policy : resolver_policy<Tag>::type {
                     resolve_function resolve, resolver_type& resolver,
                     bool https,
                     optional<string_type> const& certificate_filename,
-                    optional<string_type> const& verify_path) {
+                    optional<string_type> const& verify_path,
+                    optional<string_type> const& certificate_file,
+                    optional<string_type> const& private_key_file) {
       pimpl = impl::async_connection_base<
           Tag, version_major,
           version_minor>::new_connection(resolve, resolver, follow_redirect,
                                          always_verify_peer, https,
-                                         certificate_filename, verify_path);
+                                         certificate_filename, verify_path,
+                                         certificate_file, private_key_file);
     }
 
     basic_response<Tag> send_request(string_type const& method,
@@ -67,7 +70,11 @@ struct async_connection_policy : resolver_policy<Tag>::type {
       bool always_verify_peer,
       optional<string_type> const& certificate_filename =
           optional<string_type>(),
-      optional<string_type> const& verify_path = optional<string_type>()) {
+      optional<string_type> const& verify_path =
+          optional<string_type>(),
+      optional<string_type> const& certificate_file =
+          optional<string_type>(),
+      optional<string_type> const& private_key_file = optional<string_type>()) {
     string_type protocol_ = protocol(request_);
     connection_ptr connection_(new connection_impl(
         follow_redirect_, always_verify_peer,
@@ -75,7 +82,8 @@ struct async_connection_policy : resolver_policy<Tag>::type {
                                              version_minor>::resolve,
                     this, _1, _2, _3, _4),
         resolver, boost::iequals(protocol_, string_type("https")),
-        certificate_filename, verify_path));
+        certificate_filename, verify_path,
+        certificate_file, private_key_file));
     return connection_;
   }
 

--- a/boost/network/protocol/http/policies/simple_connection.hpp
+++ b/boost/network/protocol/http/policies/simple_connection.hpp
@@ -47,12 +47,17 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
                     optional<string_type> const& certificate_filename =
                         optional<string_type>(),
                     optional<string_type> const& verify_path =
+                        optional<string_type>(),
+                    optional<string_type> const& certificate_file =
+                        optional<string_type>(),
+                    optional<string_type> const& private_key_file =
                         optional<string_type>())
         : pimpl(), follow_redirect_(follow_redirect) {
       pimpl.reset(impl::sync_connection_base<
           Tag, version_major,
           version_minor>::new_connection(resolver, resolve, https,
-                                         certificate_filename, verify_path));
+                                         certificate_filename, verify_path,
+                                         certificate_file, private_key_file));
     }
 
     basic_response<Tag> send_request(string_type const& method,
@@ -104,9 +109,13 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
   connection_ptr get_connection(resolver_type& resolver,
                                 basic_request<Tag> const& request_,
                                 bool always_verify_peer,
+                                optional<string_type> const& certificate_filename =
+                                    optional<string_type>(),
+                                optional<string_type> const& verify_path =
+                                    optional<string_type>(),
                                 optional<string_type> const& certificate_file =
                                     optional<string_type>(),
-                                optional<string_type> const& verify_file =
+                                optional<string_type> const& private_key_file =
                                     optional<string_type>()) {
     connection_ptr connection_(new connection_impl(
         resolver, follow_redirect_, always_verify_peer, request_.host(),
@@ -115,7 +124,8 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
                                               version_minor>::resolve,
                     this, _1, _2, _3),
         boost::iequals(request_.protocol(), string_type("https")),
-        certificate_file, verify_file));
+        certificate_filename, verify_path,
+        certificate_file, private_key_file));
     return connection_;
   }
 

--- a/libs/network/test/http/client_constructor_test.cpp
+++ b/libs/network/test/http/client_constructor_test.cpp
@@ -21,5 +21,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(http_cient_constructor_params_test, client, client
     typename client::options options;
     client instance(options.follow_redirects(true).cache_resolved(true));
     client instance2(options.openssl_certificate("foo").openssl_verify_path("bar"));
-    client instance3(options.follow_redirects(true).io_service(boost::make_shared<boost::asio::io_service>()).cache_resolved(true));
+    client instance3(options.openssl_certificate_file("foo").openssl_private_key_file("bar"));
+    client instance4(options.follow_redirects(true).io_service(boost::make_shared<boost::asio::io_service>()).cache_resolved(true));
 }


### PR DESCRIPTION
Added client::options to openssl_certificate_file() and openssl_private_key_file(). They correspond to Boost.Asio's use_certificate_file() and use_private_key_file().

Naming decisions:
1. The same as other member functions naming rules. (e.g. openssl_verify_path() )
2. Easy to find the Boost.Asio's corresponding member functions.

Note:
I have an idea to rename the existing member function openssl_certificate() to some different name. But it would be a breaking change and I believe that I shouldn't include it in this pull request.
The reasons that I'd like to rename openssl_certificate() are as follows:
1. openssl_certificate() corresponds to Boost.Asio's load_verify_file() so the new name should be openssl_load_verify_file() or openssl_verify_file(). Latter is better in cpp-netlib's naming mannar.
2. This pull request adds openssl_certificate_file() and I believe that it is an apropriate name. But openssl_certificate_file() and openssl_certificate() are confusing.

If you agree with my idea, I'm ready to make a pull request. For existing users, keeping openssl_certificate() as a deprecated alias of openssl_verify_file().
