### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,8 @@
 *.swp
 *.pyc
-CMakeCache.txt
-CMakeFiles
-Makefile
-Testing
 *.gch
 libs/mime/test/mime-roundtrip
-*.a
 bin/
 tests/
 _build
-CPP-NETLIB.*
-CMakeScripts/
 *~


### PR DESCRIPTION
Current gitignore state is inconsistent: files with mask `*.cmake` is ignored
but there is a file FindICU.cmake.
