### PR TITLE
Fix compiler warnings

### DIFF
--- a/logging/test/logging_log_record.cpp
+++ b/logging/test/logging_log_record.cpp
@@ -8,7 +8,9 @@
 #include <gtest/gtest.h>
 
 #include <network/logging/logging.hpp>
-#define NETWORK_ENABLE_LOGGING
+#ifndef NETWORK_ENABLE_LOGGING
+# define NETWORK_ENABLE_LOGGING
+#endif
 #include <network/detail/debug.hpp>
 
 using namespace network::logging;

--- a/message/src/network/detail/debug.hpp
+++ b/message/src/network/detail/debug.hpp
@@ -15,7 +15,7 @@
 
     The user can force the logging to be enabled by defining NETWORK_ENABLE_LOGGING.
 */
-#if defined(NETWORK_DEBUG) && defined(NETWORK_ENABLE_LOGGING)
+#if defined(NETWORK_DEBUG) && !defined(NETWORK_ENABLE_LOGGING)
 #define NETWORK_ENABLE_LOGGING
 #endif
 


### PR DESCRIPTION
Do not definee NETWORK_ENABLE_LOGGING if already defined
