### PR TITLE
fix build path for mime test

### DIFF
--- a/libs/mime/test/CMakeLists.txt
+++ b/libs/mime/test/CMakeLists.txt
@@ -8,6 +8,8 @@ if (NOT(${CMAKE_CXX_COMPILER_ID} MATCHES GNU AND ${CMAKE_SYSTEM_NAME} MATCHES "W
     add_executable ( mime-roundtrip mime-roundtrip.cpp )
     target_link_libraries ( mime-roundtrip ${Boost_LIBRARIES}
       ${CMAKE_THREAD_LIBS_INIT})
+    set_target_properties( mime-roundtrip
+        PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/tests)
     add_test ( mime-roundtrip ${CPP-NETLIB_BINARY_DIR}/tests/mime-roundtrip )
   endif ()
 endif()


### PR DESCRIPTION
need to make sure tests are built in the right place, otherwise test runner can't find them.
