### PR TITLE
Fixes #358 - avoid self join

### DIFF
--- a/boost/network/constants.hpp
+++ b/boost/network/constants.hpp
@@ -116,7 +116,7 @@ namespace boost { namespace network {
 
             static char const * close() {
                 static char close_[] = {
-                    'c','l','o','s','e', 0
+                    'C','l','o','s','e', 0
                 };
                 return close_;
             }


### PR DESCRIPTION
Avoid self join in async client dtor.
(https://github.com/cpp-netlib/cpp-netlib/issues/358#issuecomment-46270773)
