### PR TITLE
Fix to overwrite connection header

### DIFF
--- a/boost/network/protocol/http/algorithms/linearize.hpp
+++ b/boost/network/protocol/http/algorithms/linearize.hpp
@@ -99,14 +99,16 @@ namespace boost { namespace network { namespace http {
         // We need to determine whether we've seen any of the following headers
         // before setting the defaults. We use a bitset to keep track of the
         // defaulted headers.
-        enum { ACCEPT, ACCEPT_ENCODING, HOST, MAX };
+        enum { ACCEPT, ACCEPT_ENCODING, HOST, CONNECTION, MAX };
         std::bitset<MAX> found_headers;
         static char const* defaulted_headers[][2] = {
           {consts::accept(),
            consts::accept() + std::strlen(consts::accept())},
           {consts::accept_encoding(),
            consts::accept_encoding() + std::strlen(consts::accept_encoding())},
-          {consts::host(), consts::host() + std::strlen(consts::host())}
+          {consts::host(), consts::host() + std::strlen(consts::host())},
+          {consts::connection(),
+           consts::connection() + std::strlen(consts::connection())}
         };
 
         typedef typename headers_range<Request>::type headers_range;
@@ -167,7 +169,8 @@ namespace boost { namespace network { namespace http {
           boost::copy(crlf, oi);
         }
 
-        if (!connection_keepalive<Tag>::value) {
+        if (!connection_keepalive<Tag>::value &&
+            !found_headers[CONNECTION]) {
           boost::copy(connection, oi);
           *oi = consts::colon_char();
           *oi = consts::space_char();


### PR DESCRIPTION
Sometimes, the default value of connection header can be needed to change.

For example, [http_client.cpp:64](https://github.com/cpp-netlib/cpp-netlib/blob/0.11-devel/libs/network/example/http_client.cpp#L64) has used lowercase "close".
