### PR TITLE
Various changes investigating short reads

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -26,6 +26,8 @@ flags = [
     '/usr/include/c++/4.6',
     '-isystem',
     '/usr/include/clang/3.0/include',
+    '-isystem',
+    '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/c++/v1',
     '-I',
     os.environ['BOOST_ROOT'],
     # Always enable debugging for the project when building for semantic

--- a/boost/network/protocol/http/message/wrappers/status_message.hpp
+++ b/boost/network/protocol/http/message/wrappers/status_message.hpp
@@ -1,11 +1,14 @@
 #ifndef BOOST_NETWORK_PROTOCOL_HTTP_MESSAGE_WRAPPERS_STATUS_MESSAGE_HPP_20100603
 #define BOOST_NETWORK_PROTOCOL_HTTP_MESSAGE_WRAPPERS_STATUS_MESSAGE_HPP_20100603
 
-// Copyright 2010 (c) Dean Michael Berris
+// Copyright 2010 (c) Dean Michael Berris <dberris@google.com>
 // Copyright 2010 (c) Sinefunc, Inc.
+// Copyright 2014 (c) Google, Inc.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/network/traits/string.hpp>
 
 namespace boost { namespace network { namespace http {
 
@@ -27,11 +30,18 @@ namespace boost { namespace network { namespace http {
             status_message_wrapper(status_message_wrapper const & other)
                 : response_(other.response_) {}
 
-            operator string_type () {
+            operator string_type () const {
                 return response_.status_message();
             }
 
         };
+
+	template <class Tag>
+	inline std::ostream&
+	operator<<(std::ostream& os,
+		   const status_message_wrapper<Tag>& wrapper) {
+	  return os << static_cast<typename string<Tag>::type>(wrapper);
+	}
 
     } // namespace impl
 

--- a/libs/network/example/CMakeLists.txt
+++ b/libs/network/example/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(twitter_search twitter/search.cpp)
 add_executable(hello_world_server http/hello_world_server.cpp)
 add_executable(hello_world_client http/hello_world_client.cpp)
 add_executable(hello_world_async_server_with_work_queue http/hello_world_async_server_with_work_queue.cpp)
+add_executable(trivial_google trivial_google.cpp)
 if (UNIX)
   add_executable(fileserver http/fileserver.cpp)
 endif (UNIX)
@@ -24,6 +25,7 @@ add_dependencies(simple_wget cppnetlib-uri cppnetlib-client-connections)
 add_dependencies(atom_reader cppnetlib-uri cppnetlib-client-connections)
 add_dependencies(rss_reader cppnetlib-uri cppnetlib-client-connections)
 add_dependencies(twitter_search cppnetlib-uri cppnetlib-client-connections)
+add_dependencies(trivial_google cppnetlib-uri cppnetlib-client-connections)
 set(BOOST_CLIENT_LIBS
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_THREAD_LIBRARY}
@@ -71,6 +73,12 @@ target_link_libraries(twitter_search
     cppnetlib-uri
     cppnetlib-client-connections)
 
+target_link_libraries(trivial_google
+  ${BOOST_CLIENT_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+  cppnetlib-uri
+  cppnetlib-client-connections)
+
 target_link_libraries(hello_world_server
     ${BOOST_SERVER_LIBS}
     ${CMAKE_THREAD_LIBS_INIT})
@@ -97,6 +105,7 @@ if (OPENSSL_FOUND)
   target_link_libraries(hello_world_server ${OPENSSL_LIBRARIES})
   target_link_libraries(hello_world_client ${OPENSSL_LIBRARIES})
   target_link_libraries(hello_world_async_server_with_work_queue ${OPENSSL_LIBRARIES})
+  target_link_libraries(trivial_google ${OPENSSL_LIBRARIES})
 endif (OPENSSL_FOUND)
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES GNU AND ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -108,6 +117,7 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES GNU AND ${CMAKE_SYSTEM_NAME} MATCHES "Windo
   target_link_libraries(hello_world_server ws2_32 wsock32)
   target_link_libraries(hello_world_client ws2_32)
   target_link_libraries(hello_world_async_server_with_work_queue ws2_32 wsock32)
+  target_link_libraries(trivial_google ws2_32)
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -119,6 +129,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   target_link_libraries(hello_world_server rt)
   target_link_libraries(hello_world_client rt)
   target_link_libraries(hello_world_async_server_with_work_queue rt)
+  target_link_libraries(trivial_google rt)
 endif()
 
 if (UNIX)
@@ -140,9 +151,11 @@ set_target_properties(simple_wget PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETL
 set_target_properties(atom_reader PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
 set_target_properties(rss_reader PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
 set_target_properties(twitter_search PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
+set_target_properties(trivial_google PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
 set_target_properties(hello_world_server PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
 set_target_properties(hello_world_client PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
 set_target_properties(hello_world_async_server_with_work_queue PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
+
 if (UNIX)
   set_target_properties(fileserver PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
 endif (UNIX)

--- a/libs/network/example/http_client.cpp
+++ b/libs/network/example/http_client.cpp
@@ -1,8 +1,9 @@
 
-//          Copyright Dean Michael Berris 2008.
+// Copyright 2008, 2014 Dean Michael Berris <dberris@google.com>
+// Copyright 2014 Google, Inc.
 // Distributed under the Boost Software License, Version 1.0.
-//    (See accompanying file LICENSE_1_0.txt or copy at
-//          http://www.boost.org/LICENSE_1_0.txt)
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
 
 //[ http_client_main
 /*`
@@ -25,6 +26,7 @@ int main(int argc, char * argv[]) {
     options.add_options()
         ("help,h", "produce help message")
         ("headers,H", "print headers")
+	("status,S", "print status and message")
         ("source,s", po::value<std::string>(&source), "source URL")
         ;
 
@@ -39,44 +41,44 @@ int main(int argc, char * argv[]) {
         std::cout << "Error: " << e.what() << std::endl;
         std::cout << options << std::endl;
         return EXIT_FAILURE;
-    };
+    }
 
     if (vm.count("help")) {
         std::cout << options << std::endl;
         return EXIT_SUCCESS;
-    };
+    }
 
     if (vm.count("source") < 1) {
         std::cout << "Error: Source URL required." << std::endl;
         std::cout << options << std::endl;
         return EXIT_FAILURE;
-    };
+    }
 
-    show_headers = vm.count("headers") ? true : false ;
+    show_headers = vm.count("headers") ? true : false;
+    bool show_status = vm.count("status") ? true : false;
 
-
-    typedef http::basic_client<http::tags::http_async_8bit_tcp_resolve, 1, 0>
-        http_client;
-
-    http_client::request request(source);
-    http_client::string_type destination_ = host(request);
+    http::client::request request(source);
+    http::client::string_type destination_ = host(request);
 
     request << ::boost::network::header("Connection", "close");
-    http_client::options client_options;
-    http_client client(client_options.follow_redirects(true));
-    http_client::response response = client.get(request);
+    http::client::options client_options;
+    client_options.follow_redirects(true);
+    http::client client(client_options);
+    http::client::response response = client.get(request);
+
+    if (show_status)
+      std::cout << status(response) << " " << status_message(response) << std::endl;
 
     if (show_headers) {
-        headers_range<http_client::response>::type headers_ = response.headers();
+        headers_range<http::client::response>::type headers_ = response.headers();
         typedef std::pair<std::string, std::string> header_type;
         BOOST_FOREACH(header_type const & header, headers_) {
           std::cout << header.first << ": " << header.second << std::endl;
         }
         std::cout << std::endl;
-    };
+    }
 
-    body_range<http_client::response>::type body_ = body(response).range();
-    boost::copy(body_, std::ostream_iterator<char_<http_client::request::tag>::type>(std::cout));
+    std::cout << body(response);
     return EXIT_SUCCESS;
 }
 //]

--- a/libs/network/example/simple_wget.cpp
+++ b/libs/network/example/simple_wget.cpp
@@ -43,8 +43,8 @@ main(int argc, char *argv[]) {
         return 1;
     }
 
+    http::client client;
     try {
-        http::client client;
         http::client::request request(argv[1]);
         http::client::response response = client.get(request);
 

--- a/libs/network/example/trivial_google.cpp
+++ b/libs/network/example/trivial_google.cpp
@@ -1,0 +1,18 @@
+// Copyright 2014 Dean Michael Berris <dberris@google.com>
+// Copyright 2014 Google, Inc.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+
+#include <boost/network/include/http/client.hpp>
+
+namespace http = boost::network::http;
+
+int main(int, char*[]) {
+  http::client client;
+  http::client::request request("https://www.google.com/");
+  http::client::response response = client.get(request);
+  std::cout << body(response) << std::endl;
+}


### PR DESCRIPTION
This is in relation to issue #425 where a report of a short_read still
happening in Linux (Debian) with GCC/Clang. This couldn't be reproduced
with an OpenSSL acquired via Homebrew on Mac OS X.

More tests would require specific OpenSSL versions, which may or may
not exhibit this issue.
