### PR TITLE
Workaround Boost.Optional 1.56.0 MSVC 2010 Issue

### DIFF
--- a/boost/network/protocol/http/message/wrappers/port.hpp
+++ b/boost/network/protocol/http/message/wrappers/port.hpp
@@ -1,13 +1,16 @@
 #ifndef BOOST_NETWORK_PROTOCOL_HTTP_MESSAGE_PORT_HPP_20100618
 #define BOOST_NETWORK_PROTOCOL_HTTP_MESSAGE_PORT_HPP_20100618
 
-// Copyright 2010 (c) Dean Michael Berris.
+// Copyright 2010, 2014 Dean Michael Berris <dberris@google.com>
 // Copyright 2010 (c) Sinefunc, Inc.
+// Copyright 2014 Google, Inc.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/optional.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/network/uri/accessors.hpp>
 
 namespace boost {
 namespace network {
@@ -26,11 +29,26 @@ struct port_wrapper {
 
   typedef typename basic_request<Tag>::port_type port_type;
 
-  operator port_type() { return message_.port(); }
+  operator port_type() const { return message_.port(); }
 
-  operator boost::optional<boost::uint16_t>() {
+#if (_MSC_VER == 1600)
+  // We hack this so that we don't run into the issue of MSVC 2010 not doing the
+  // right thing when converting/copying Boost.Optional objects.
+  struct optional_wrapper {
+    boost::optional<boost::uint16_t> o_;
+    explicit optional_wrapper(boost::optional<boost::uint16_t> o) : o_(o) {}
+    operator boost::optional<boost::uint16_t>() { return o_; }
+  };
+
+  operator optional_wrapper() const {
+    return optional_wrapper(uri::port_us(message_.uri()));
+  }
+#else
+  operator boost::optional<boost::uint16_t>() const {
     return uri::port_us(message_.uri());
   }
+#endif
+
 };
 
 }  // namespace impl
@@ -41,9 +59,7 @@ inline impl::port_wrapper<Tag> port(basic_request<Tag> const& request) {
 }
 
 }  // namespace http
-
 }  // namespace network
-
 }  // namespace boost
 
 #endif  // BOOST_NETWORK_PROTOCOL_HTTP_MESSAGE_PORT_HPP_20100618


### PR DESCRIPTION
This change takes the advice of the Boost.Optional maintainer when
working around the breaking changes in Boost.Optional 1.56.0 --
apparently MSVC has a bug in copy-construction resolution which
considers multiple conversions (not a standard-conforming extension)
and because of changes to the Boost.Optional interface is being hit.

This commit only works around the MSVC 2010 compiler. It may be that
the bug is also in newer versions of the compiler, but that I'm less
sure about.

Fixes #419 
