### PR TITLE
Fix for issue #419

### DIFF
--- a/boost/network/protocol/http/algorithms/linearize.hpp
+++ b/boost/network/protocol/http/algorithms/linearize.hpp
@@ -19,6 +19,7 @@
 #include <boost/optional.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/algorithm/string/compare.hpp>
+#include <boost/version.hpp>
 
 namespace boost {
 namespace network {
@@ -138,7 +139,12 @@ BOOST_CONCEPT_REQUIRES(((ClientRequest<Request>)), (OutputIterator))
     *oi = consts::colon_char();
     *oi = consts::space_char();
     boost::copy(request.host(), oi);
-    boost::optional<boost::uint16_t> port_ = port(request).as_optional();
+    boost::optional<boost::uint16_t> port_ =
+#if (_MSC_VER >= 1600 && BOOST_VERSION > 105500)
+      port(request).as_optional();
+#else
+      port(request);
+#endif
     if (port_) {
       string_type port_str = boost::lexical_cast<string_type>(*port_);
       *oi = consts::colon_char();

--- a/boost/network/protocol/http/message/wrappers/port.hpp
+++ b/boost/network/protocol/http/message/wrappers/port.hpp
@@ -12,6 +12,7 @@
 #include <boost/optional.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/network/uri/accessors.hpp>
+#include <boost/version.hpp>
 
 namespace boost {
 namespace network {
@@ -32,21 +33,19 @@ struct port_wrapper {
 
   operator port_type() const { return message_.port(); }
 
-#if !defined(_MSC_VER)
+#if (_MSC_VER >= 1600 && BOOST_VERSION > 105500)
   // Because of a breaking change in Boost 1.56 to boost::optional, implicit
   // conversions no longer work correctly with MSVC. The conversion therefore
-  // has to be done explicitly with as_optional(). This method is here just
-  // to maintain backwards compatibility with compilers not affected by the
-  // change.
+  // has to be done explicitly with as_optional().
+  boost::optional<boost::uint16_t> as_optional() const {
+    return uri::port_us(message_.uri());
+  }
+#else
   operator boost::optional<boost::uint16_t>() const {
     return uri::port_us(message_.uri());
   }
 #endif
-  
-  boost::optional<boost::uint16_t> as_optional() const {
-    return uri::port_us(message_.uri());
-  }
-
+ 
 };
 
 }  // namespace impl


### PR DESCRIPTION
This pull request fixes issue #419.

The implementation is not optimal as it removes the implicit conversion operator from MSVC builds. Conversions to boost::optional<uint16_t> should therefore done explicitly from here on.
