### PR TITLE
MSVC fixes. Noexcept and =default for move.

### DIFF
--- a/http/src/http/server/session.hpp
+++ b/http/src/http/server/session.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <unordered_map>
 #include <boost/utility/string_ref.hpp>
+#include <network/config.hpp>
 
 namespace network {
 namespace http {
@@ -17,9 +18,9 @@ namespace http {
 struct session {
   session() = default;
   session(const session&) = default;
-  session(session&&) = default;
+  session(session&&) NETWORK_DEFAULTED_FUNCTION;
   session& operator=(const session&) = default;
-  session& operator=(session&&) = default;
+  session& operator=(session&&) NETWORK_DEFAULTED_FUNCTION;
 
   void set(boost::string_ref key, boost::string_ref value, bool server_only = false);
   std::string get(boost::string_ref key, boost::string_ref default_value) const;

--- a/http/src/http/v2/client/client.cpp
+++ b/http/src/http/v2/client/client.cpp
@@ -54,7 +54,7 @@ namespace network {
              std::unique_ptr<client_connection::async_connection> mock_connection,
              client_options options);
 
-        ~impl() noexcept;
+        ~impl() NETWORK_NOEXCEPT;
 
         std::future<response> execute(std::shared_ptr<request_helper> helper);
 
@@ -114,7 +114,7 @@ namespace network {
 
       }
 
-      client::impl::~impl() noexcept {
+      client::impl::~impl() NETWORK_NOEXCEPT {
         sentinel_.reset();
         lifetime_thread_.join();
       }
@@ -331,7 +331,7 @@ namespace network {
                      client_options options)
         : pimpl_(new impl(std::move(mock_resolver), std::move(mock_connection), options)) { }
 
-      client::~client() noexcept {
+      client::~client() NETWORK_NOEXCEPT {
         delete pimpl_;
       }
 

--- a/http/src/http/v2/client/client_errors.cpp
+++ b/http/src/http/v2/client/client_errors.cpp
@@ -17,19 +17,19 @@ namespace network {
 
 	client_category_impl() = default;
 
-	virtual ~client_category_impl() noexcept;
+	virtual ~client_category_impl() NETWORK_NOEXCEPT;
 
-	virtual const char *name() const noexcept;
+	virtual const char *name() const NETWORK_NOEXCEPT;
 
 	virtual std::string message(int ev) const;
 
       };
 
-      client_category_impl::~client_category_impl() noexcept {
+      client_category_impl::~client_category_impl() NETWORK_NOEXCEPT {
 
       }
 
-      const char *client_category_impl::name() const noexcept {
+      const char *client_category_impl::name() const NETWORK_NOEXCEPT {
 	static const char name[] = "client_error";
 	return name;
       }
@@ -61,7 +61,7 @@ namespace network {
 
       }
 
-      invalid_url::~invalid_url() noexcept {
+      invalid_url::~invalid_url() NETWORK_NOEXCEPT {
 
       }
 
@@ -70,7 +70,7 @@ namespace network {
 
       }
 
-      client_exception::~client_exception() noexcept {
+      client_exception::~client_exception() NETWORK_NOEXCEPT {
 
       }
 

--- a/http/src/network/http/v2/client/client.hpp
+++ b/http/src/network/http/v2/client/client.hpp
@@ -95,14 +95,14 @@ namespace network {
         /**
          * \brief Destructor.
          */
-        ~client_options() noexcept {
+        ~client_options() NETWORK_NOEXCEPT {
 
         }
 
         /**
          * \brief Swap.
          */
-        void swap(client_options &other) noexcept {
+        void swap(client_options &other) NETWORK_NOEXCEPT {
           using std::swap;
           std::swap(io_service_, other.io_service_);
           swap(follow_redirects_, other.follow_redirects_);
@@ -276,7 +276,7 @@ namespace network {
       };
 
       inline
-      void swap(client_options &lhs, client_options &rhs) noexcept {
+      void swap(client_options &lhs, client_options &rhs) NETWORK_NOEXCEPT {
         lhs.swap(rhs);
       }
 
@@ -316,7 +316,7 @@ namespace network {
         /**
          * \brief Destructor.
          */
-        ~client() noexcept;
+        ~client() NETWORK_NOEXCEPT;
 
         /**
          * \brief Executes an HTTP request.

--- a/http/src/network/http/v2/client/client_errors.hpp
+++ b/http/src/network/http/v2/client/client_errors.hpp
@@ -59,7 +59,7 @@ namespace network {
         /**
          * \brief Destructor.
          */
-        virtual ~invalid_url() noexcept;
+        virtual ~invalid_url() NETWORK_NOEXCEPT;
 
       };
 
@@ -80,7 +80,7 @@ namespace network {
         /**
          * \brief Destructor.
          */
-        virtual ~client_exception() noexcept;
+        virtual ~client_exception() NETWORK_NOEXCEPT;
 
       };
 

--- a/http/src/network/http/v2/client/connection/async_connection.hpp
+++ b/http/src/network/http/v2/client/connection/async_connection.hpp
@@ -56,7 +56,7 @@ namespace network {
           /**
            * \brief Destructor.
            */
-          virtual ~async_connection() noexcept { }
+          virtual ~async_connection() NETWORK_NOEXCEPT { }
 
           /**
            * \brief Asynchronously creates a connection to an endpoint.

--- a/http/src/network/http/v2/client/connection/async_resolver.hpp
+++ b/http/src/network/http/v2/client/connection/async_resolver.hpp
@@ -57,7 +57,7 @@ namespace network {
           /**
            * \brief Destructor.
            */
-          virtual ~async_resolver() noexcept {
+          virtual ~async_resolver() NETWORK_NOEXCEPT {
 
           }
 

--- a/http/src/network/http/v2/client/connection/endpoint_cache.hpp
+++ b/http/src/network/http/v2/client/connection/endpoint_cache.hpp
@@ -55,7 +55,7 @@ namespace network {
             endpoint_cache().swap(*this);
           }
 
-          void swap(endpoint_cache &other) noexcept {
+          void swap(endpoint_cache &other) NETWORK_NOEXCEPT {
             endpoints_.swap(other.endpoints_);
           }
 

--- a/http/src/network/http/v2/client/connection/normal_connection.hpp
+++ b/http/src/network/http/v2/client/connection/normal_connection.hpp
@@ -35,7 +35,7 @@ namespace network {
 
           }
 
-          virtual ~normal_connection() noexcept {
+          virtual ~normal_connection() NETWORK_NOEXCEPT {
 
           }
 

--- a/http/src/network/http/v2/client/connection/ssl_connection.hpp
+++ b/http/src/network/http/v2/client/connection/ssl_connection.hpp
@@ -38,7 +38,7 @@ namespace network {
 
           }
 
-          virtual ~ssl_connection() noexcept {
+          virtual ~ssl_connection() NETWORK_NOEXCEPT {
 
           }
 

--- a/http/src/network/http/v2/client/connection/tcp_resolver.hpp
+++ b/http/src/network/http/v2/client/connection/tcp_resolver.hpp
@@ -54,7 +54,7 @@ namespace network {
           /**
            * \brief Destructor.
            */
-          virtual ~tcp_resolver() noexcept {
+          virtual ~tcp_resolver() NETWORK_NOEXCEPT {
 
           }
 

--- a/http/src/network/http/v2/client/request.hpp
+++ b/http/src/network/http/v2/client/request.hpp
@@ -83,11 +83,11 @@ namespace network {
           /**
            * \brief Destructor.
            */
-          ~request_options() noexcept {
+          ~request_options() NETWORK_NOEXCEPT {
 
           }
 
-          void swap(request_options &other) noexcept {
+          void swap(request_options &other) NETWORK_NOEXCEPT {
             using std::swap;
             swap(resolve_timeout_, other.resolve_timeout_);
             swap(read_timeout_, other.read_timeout_);
@@ -140,7 +140,7 @@ namespace network {
         };
 
         inline
-        void swap(request_options &lhs, request_options &rhs) noexcept {
+        void swap(request_options &lhs, request_options &rhs) NETWORK_NOEXCEPT {
           lhs.swap(rhs);
         }
 
@@ -169,7 +169,7 @@ namespace network {
           /**
            * \brief Destructor.
            */
-          virtual ~byte_source() noexcept {}
+          virtual ~byte_source() NETWORK_NOEXCEPT {}
 
           /**
            * \brief Allows the request to read the data into a local
@@ -308,7 +308,7 @@ namespace network {
           /**
            * \brief Move constructor.
            */
-          request(request &&other) noexcept
+          request(request &&other) NETWORK_NOEXCEPT
             : url_(std::move(other.url_))
             , method_(std::move(other.method_))
             , path_(std::move(other.path_))
@@ -327,7 +327,7 @@ namespace network {
           /**
            * \brief Destructor.
            */
-          ~request() noexcept {
+          ~request() NETWORK_NOEXCEPT {
 
           }
 
@@ -335,7 +335,7 @@ namespace network {
            * \brief Swaps one request object with another.
            * \param other The other request object.
            */
-          void swap(request &other) noexcept {
+          void swap(request &other) NETWORK_NOEXCEPT {
             using std::swap;
             swap(url_, other.url_);
             swap(method_, other.method_);
@@ -506,7 +506,7 @@ namespace network {
         };
 
         inline
-        void swap(request &lhs, request &rhs) noexcept {
+        void swap(request &lhs, request &rhs) NETWORK_NOEXCEPT {
           lhs.swap(rhs);
         }
       } // namespace client_message

--- a/http/src/network/http/v2/client/response.hpp
+++ b/http/src/network/http/v2/client/response.hpp
@@ -82,7 +82,7 @@ namespace network {
            * \brief Move constructor.
            * \param other The other response object.
            */
-          response(response &&other) noexcept
+          response(response &&other) NETWORK_NOEXCEPT
           : version_(std::move(other.version_))
             , status_(std::move(other.status_))
             , status_message_(std::move(other.status_message_))
@@ -104,7 +104,7 @@ namespace network {
            * \brief Swap function.
            * \param other The other response object.
            */
-          void swap(response &other) noexcept {
+          void swap(response &other) NETWORK_NOEXCEPT {
             using std::swap;
             swap(version_, other.version_);
             swap(status_, other.status_);
@@ -206,7 +206,7 @@ namespace network {
         };
 
         inline
-        void swap(response &lhs, response &rhs) noexcept {
+        void swap(response &lhs, response &rhs) NETWORK_NOEXCEPT {
           lhs.swap(rhs);
         }
       } // namespace client_message

--- a/message/src/CMakeLists.txt
+++ b/message/src/CMakeLists.txt
@@ -5,6 +5,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+include_directories(${CPP-NETLIB_SOURCE_DIR}/config/src/)
 include_directories(${CPP-NETLIB_SOURCE_DIR}/uri/src ${CPP-NETLIB_SOURCE_DIR}/message/src)
 
 set(CPP-NETLIB_MESSAGE_SRCS

--- a/message/src/network/message/message.hpp
+++ b/message/src/network/message/message.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <map>
 #include <functional>
+#include <network/config.hpp>
 #include <network/message/message_base.hpp>
 #include <boost/shared_container_iterator.hpp>
 
@@ -26,9 +27,7 @@ struct message : message_base {
   // Constructors
   message();
   message(message const& other);
-#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
-  message(message && other) = default;
-#endif  // !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+  message(message && other) NETWORK_DEFAULTED_FUNCTION;
 
   // Assignment
   message& operator=(message const & other);


### PR DESCRIPTION
Fixes some issues with MSVC compiler. I used /DBOOST_NO_CXX11_DEFAULTED_FUNCTIONS to get correct preprocessors. Dont know if it should be added in CMake files under Win32 configurations.
Tested with MSVC 12.
