### PR TITLE
Fix already fulfilled promise errors on long downloads + added namespacing to status constants

### DIFF
--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -322,7 +322,7 @@ struct http_async_connection
             // this can be used as a signaling mechanism for the user to
             // determine that the body is now ready for processing, even
             // though the callback is already provided.
-            this->body_promise.set_value("");
+            //this->body_promise.set_value("");
 
             // The invocation of the callback is synchronous to allow us
             // to

--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -322,7 +322,7 @@ struct http_async_connection
             // this can be used as a signaling mechanism for the user to
             // determine that the body is now ready for processing, even
             // though the callback is already provided.
-            //this->body_promise.set_value("");
+            this->body_promise.set_value("");
 
             // The invocation of the callback is synchronous to allow us
             // to
@@ -439,7 +439,12 @@ struct http_async_connection
         case headers:
           this->headers_promise.set_exception(boost::copy_exception(error));
         case body:
-          this->body_promise.set_exception(boost::copy_exception(error));
+          if (!callback) {
+            // N.B. if callback is non-null, then body_promise has
+            // already been set to value "" to indicate body is
+            // handled by streaming handler so no exception should be set
+            this->body_promise.set_exception(boost::copy_exception(error));
+          }
           break;
         default:
           BOOST_ASSERT(false && "Bug, report this to the developers!");

--- a/boost/network/protocol/http/traits/impl/response_code.ipp
+++ b/boost/network/protocol/http/traits/impl/response_code.ipp
@@ -23,17 +23,17 @@ namespace http {
  */
 template <class Tag>
 struct response_code {
-  static boost::uint16_t const OK = 200u;
-  static boost::uint16_t const CREATED = 201u;
-  static boost::uint16_t const NO_CONTENT = 204u;
-  static boost::uint16_t const UNAUTHORIZED = 401u;
-  static boost::uint16_t const FORBIDDEN = 403u;
-  static boost::uint16_t const NOT_FOUND = 404u;
-  static boost::uint16_t const METHOD_NOT_ALLOWED = 405u;
-  static boost::uint16_t const NOT_MODIFIED = 304u;
-  static boost::uint16_t const BAD_REQUEST = 400u;
-  static boost::uint16_t const SERVER_ERROR = 500u;
-  static boost::uint16_t const NOT_IMPLEMENTED = 501u;
+  static boost::uint16_t const RC_OK = 200u;
+  static boost::uint16_t const RC_CREATED = 201u;
+  static boost::uint16_t const RC_NO_CONTENT = 204u;
+  static boost::uint16_t const RC_UNAUTHORIZED = 401u;
+  static boost::uint16_t const RC_FORBIDDEN = 403u;
+  static boost::uint16_t const RC_NOT_FOUND = 404u;
+  static boost::uint16_t const RC_METHOD_NOT_ALLOWED = 405u;
+  static boost::uint16_t const RC_NOT_MODIFIED = 304u;
+  static boost::uint16_t const RC_BAD_REQUEST = 400u;
+  static boost::uint16_t const RC_SERVER_ERROR = 500u;
+  static boost::uint16_t const RC_NOT_IMPLEMENTED = 501u;
 };
 
 }  // namespace http

--- a/boost/network/protocol/http/traits/impl/response_message.ipp
+++ b/boost/network/protocol/http/traits/impl/response_message.ipp
@@ -16,58 +16,58 @@ namespace http {
 template <>
 struct response_message<tags::http_default_8bit_tcp_resolve> {
   static char const* ok() {
-    static char const* const OK = "OK";
-    return OK;
+    static char const* const RC_OK = "OK";
+    return RC_OK;
   };
 
   static char const* created() {
-    static char const* const CREATED = "Created";
-    return CREATED;
+    static char const* const RC_CREATED = "Created";
+    return RC_CREATED;
   };
 
   static char const* no_content() {
-    static char const* const NO_CONTENT = "NO Content";
-    return NO_CONTENT;
+    static char const* const RC_NO_CONTENT = "NO Content";
+    return RC_NO_CONTENT;
   };
 
   static char const* unauthorized() {
-    static char const* const UNAUTHORIZED = "Unauthorized";
-    return UNAUTHORIZED;
+    static char const* const RC_UNAUTHORIZED = "Unauthorized";
+    return RC_UNAUTHORIZED;
   };
 
   static char const* forbidden() {
-    static char const* const FORBIDDEN = "Fobidden";
-    return FORBIDDEN;
+    static char const* const RC_FORBIDDEN = "Fobidden";
+    return RC_FORBIDDEN;
   };
 
   static char const* not_found() {
-    static char const* const NOT_FOUND = "Not Found";
-    return NOT_FOUND;
+    static char const* const RC_NOT_FOUND = "Not Found";
+    return RC_NOT_FOUND;
   };
 
   static char const* method_not_allowed() {
-    static char const* const METHOD_NOT_ALLOWED = "Method Not Allowed";
-    return METHOD_NOT_ALLOWED;
+    static char const* const RC_METHOD_NOT_ALLOWED = "Method Not Allowed";
+    return RC_METHOD_NOT_ALLOWED;
   };
 
   static char const* not_modified() {
-    static char const* const NOT_MODIFIED = "Not Modified";
-    return NOT_MODIFIED;
+    static char const* const RC_NOT_MODIFIED = "Not Modified";
+    return RC_NOT_MODIFIED;
   };
 
   static char const* bad_request() {
-    static char const* const BAD_REQUEST = "Bad Request";
-    return BAD_REQUEST;
+    static char const* const RC_BAD_REQUEST = "Bad Request";
+    return RC_BAD_REQUEST;
   };
 
   static char const* server_error() {
-    static char const* const SERVER_ERROR = "Server Error";
-    return SERVER_ERROR;
+    static char const* const RC_SERVER_ERROR = "Server Error";
+    return RC_SERVER_ERROR;
   };
 
   static char const* not_implemented() {
-    static char const* const NOT_IMPLEMENTED = "Not Implemented";
-    return NOT_IMPLEMENTED;
+    static char const* const RC_NOT_IMPLEMENTED = "Not Implemented";
+    return RC_NOT_IMPLEMENTED;
   };
 };
 


### PR DESCRIPTION
I had the same problem as the second issue described in the following Google Groups post:

https://groups.google.com/forum/#!topic/cpp-netlib/ERc1bUa2p6M

That is to say, during long downloads when using the async HTTP client, if the request errors after the header is received (e.g. I often get this with a 104 system error - Connection reset by peer as described in the post), a `boost::promise_already_satisfied` error is raised on the next read since for some reason the value of `body_promise` is set to an empty string on completion of header download, causing an issue when an attempt is made to set the promise to the exception in the body case. I commented out the setting of the promise value upon successful download of the header.

A comment by that line reads:

    // We're setting the body promise here to an empty string because
    // this can be used as a signaling mechanism for the user to
    // determine that the body is now ready for processing, even
    // though the callback is already provided

But I could not find anywhere where this is used in the code (maybe there is?) and this fixed the problem for me. An alternative would be to not set the exception of the `body_promise` later on, but this doesn't seem ideal. Let me know if you think there is some better way to fix this.

I've also added some namespacing to the constants in http/traits/impl/response_code.ipp, since in particular the  `NOT_IMPLEMENTED` constant was causing compilation errors with several libraries that I use which also define this constant using `#define`, which seems to be quite common when using the Google Logging library.