### PR TITLE
Fixed compilation warnings.

### DIFF
--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -199,6 +199,7 @@ struct http_async_connection
                            body_generator_function_type generator,
                            boost::system::error_code const& ec,
                            std::size_t bytes_transferred) {
+    // TODO(dberris): review parameter necessity.
     (void)bytes_transferred;
 
     if (!is_timedout_ && !ec) {

--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -46,6 +46,7 @@ struct http_async_protocol_handler {
 
   template <class ResponseType>
   void init_response(ResponseType& response_, bool get_body) {
+    // TODO(dberris): review parameter necessity.
     (void)get_body;
 
     boost::shared_future<string_type> source_future(

--- a/boost/network/protocol/http/client/connection/normal_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/normal_delegate.ipp
@@ -22,6 +22,7 @@ void boost::network::http::impl::normal_delegate::connect(
     asio::ip::tcp::endpoint &endpoint, std::string host,
     function<void(system::error_code const &)> handler) {
 
+  // TODO(dberris): review parameter necessity.
   (void)host;
 
   socket_.reset(new asio::ip::tcp::socket(service_));

--- a/boost/network/protocol/http/client/connection/sync_base.hpp
+++ b/boost/network/protocol/http/client/connection/sync_base.hpp
@@ -102,6 +102,7 @@ struct sync_connection_base_impl {
   template <class Socket>
   void send_request_impl(Socket& socket_, string_type const& method,
                          boost::asio::streambuf& request_buffer) {
+    // TODO(dberris): review parameter necessity.
     (void)method;
 
     write(socket_, request_buffer);
@@ -111,6 +112,7 @@ struct sync_connection_base_impl {
   void read_body_normal(Socket& socket_, basic_response<Tag>& response_,
                         boost::asio::streambuf& response_buffer,
                         typename ostringstream<Tag>::type& body_stream) {
+    // TODO(dberris): review parameter necessity.
     (void)response_;
 
     boost::system::error_code error;

--- a/boost/network/protocol/http/policies/pooled_connection.hpp
+++ b/boost/network/protocol/http/policies/pooled_connection.hpp
@@ -67,6 +67,7 @@ struct pooled_connection_policy : resolver_policy<Tag>::type {
           certificate_file_(certificate_file),
           private_key_file_(private_key_file) {
 
+      // TODO(dberris): review parameter necessity.
       (void)host;
       (void)port;
     }
@@ -83,6 +84,7 @@ struct pooled_connection_policy : resolver_policy<Tag>::type {
         string_type const& method, basic_request<Tag> request_, bool get_body,
         body_callback_function_type callback,
         body_generator_function_type generator) {
+      // TODO(dberris): review parameter necessity.
       (void)callback;
 
       boost::uint8_t count = 0;

--- a/boost/network/protocol/http/policies/simple_connection.hpp
+++ b/boost/network/protocol/http/policies/simple_connection.hpp
@@ -51,6 +51,7 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
         optional<string_type> const& private_key_file = optional<string_type>())
         : pimpl(), follow_redirect_(follow_redirect) {
 
+      // TODO(dberris): review parameter necessity.
       (void)hostname;
       (void)port;
 
@@ -66,6 +67,7 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
                                      basic_request<Tag> request_, bool get_body,
                                      body_callback_function_type callback,
                                      body_generator_function_type generator) {
+      // TODO(dberris): review parameter necessity.
       (void)callback;
 
       basic_response<Tag> response_;


### PR DESCRIPTION
Suppressed "unused variable" warnings with "(void)var;"
