### PR TITLE
Peer verification using OpenSSL environment variables

### DIFF
--- a/boost/network/protocol/http/client/connection/ssl_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.ipp
@@ -34,8 +34,11 @@ void boost::network::http::impl::ssl_delegate::connect(
       context_->load_verify_file(*certificate_filename_);
     if (verify_path_) context_->add_verify_path(*verify_path_);
   } else {
-    if (always_verify_peer_)
-      context_->set_verify_mode(asio::ssl::context::verify_peer);
+	  if ( always_verify_peer_ )
+	  {
+		  context_->set_verify_mode( asio::ssl::context::verify_peer );
+		  context_->set_default_verify_paths();	// use openssl default verify paths.  uses openssl environment variables SSL_CERT_DIR, SSL_CERT_FILE
+	  }
     else
       context_->set_verify_mode(asio::ssl::context::verify_none);
   }

--- a/boost/network/protocol/http/client/connection/ssl_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.ipp
@@ -34,11 +34,10 @@ void boost::network::http::impl::ssl_delegate::connect(
       context_->load_verify_file(*certificate_filename_);
     if (verify_path_) context_->add_verify_path(*verify_path_);
   } else {
-	  if ( always_verify_peer_ )
-	  {
-		  context_->set_verify_mode( asio::ssl::context::verify_peer );
-		  context_->set_default_verify_paths();	// use openssl default verify paths.  uses openssl environment variables SSL_CERT_DIR, SSL_CERT_FILE
-	  }
+    if (always_verify_peer_) {
+      context_->set_verify_mode(asio::ssl::context::verify_peer);
+	  context_->set_default_verify_paths();	// use openssl default verify paths.  uses openssl environment variables SSL_CERT_DIR, SSL_CERT_FILE
+	}
     else
       context_->set_verify_mode(asio::ssl::context::verify_none);
   }

--- a/boost/network/protocol/http/client/options.hpp
+++ b/boost/network/protocol/http/client/options.hpp
@@ -95,6 +95,11 @@ struct client_options {
     return *this;
   }
 
+  client_options& always_verify_peer(bool v) {
+    always_verify_peer_ = v;
+    return *this;
+  }
+
   client_options& timeout(int v) {
     timeout_ = v;
     return *this;


### PR DESCRIPTION
OpenSSL can use the environment variables SSL_CERT_DIR, SSL_CERT_FILE for loading of peer verification files instead of manually loading them via certificate files or verify paths.  Boost asio provides a facility for this via context->set_default_verify_paths, which cpp-netlib must call when not providing the verfication file or directory.  

Also, options.hpp does not provide a setter method for always_verify_peer, so it cannot be changed to true.

Tested on Windows, should work on *nix.