### PR TITLE
Fix parsing of HTTP Headers whitespace

### DIFF
--- a/boost/network/protocol/http/client/connection/sync_base.hpp
+++ b/boost/network/protocol/http/client/connection/sync_base.hpp
@@ -84,7 +84,7 @@ struct sync_connection_base_impl {
     string_type header_line, name;
     while (std::getline(response_stream, header_line) && header_line != "\r") {
       trim_right_if(header_line, boost::is_space() || boost::is_any_of("\r"));
-      typename string_type::size_type colon_offset;
+      typename string_type::size_type colon_offset, value_offset;
       if (header_line.size() && header_line[0] == ' ') {
         assert(!name.empty());
         if (name.empty())
@@ -94,7 +94,8 @@ struct sync_connection_base_impl {
       } else if ((colon_offset = header_line.find_first_of(':')) !=
                  string_type::npos) {
         name = header_line.substr(0, colon_offset);
-        response_ << header(name, header_line.substr(colon_offset + 2));
+        value_offset = header_line.find_first_not_of(' ', colon_offset + 1);
+        response_ << header(name, header_line.substr(value_offset, header_line.size() - value_offset));
       }
     }
   }


### PR DESCRIPTION
search for the first non space character after the colon