### PR TITLE
Export dependency libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,11 +119,12 @@ export(PACKAGE cppnetlib)
 file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}"
     "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 # ... for the build tree
-set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}")
+set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}" ${Boost_INCLUDE_DIRS})
 configure_file(cppnetlibConfig.cmake.in
     "${PROJECT_BINARY_DIR}/cppnetlibConfig.cmake" @ONLY)
 # ... for the install tree
 set(CONF_INCLUDE_DIRS "\${CPPNETLIB_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+set(CONF_INCLUDE_DIRS ${CONF_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 configure_file(cppnetlibConfig.cmake.in
     "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/cppnetlibConfig.cmake" @ONLY)
 # ... for both

--- a/cppnetlibConfig.cmake.in
+++ b/cppnetlibConfig.cmake.in
@@ -3,11 +3,11 @@
 #  CPPNETLIB_INCLUDE_DIRS - include directories for cppnetlib
 #  CPPNETLIB_LIBRARIES    - libraries to link against
 #  CPPNETLIB_EXECUTABLE   - the bar executable
- 
+
 # Compute paths
 get_filename_component(CPPNETLIB_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(CPPNETLIB_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
- 
+
 # Our library dependencies (contains definitions for IMPORTED targets)
 if(    NOT TARGET cppnetlib-client-connections
    AND NOT TARGET cppnetlib-server-parsers
@@ -15,9 +15,9 @@ if(    NOT TARGET cppnetlib-client-connections
    AND NOT CPPNETLIB_BINARY_DIR)
   include("${CPPNETLIB_CMAKE_DIR}/cppnetlibTargets.cmake")
 endif()
- 
+
 # These are IMPORTED targets created by cppnetlibTargets.cmake
-set(CPPNETLIB_LIBRARIES 
+set(CPPNETLIB_LIBRARIES
     cppnetlib-client-connections
     cppnetlib-server-parsers
     cppnetlib-uri)

--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 include_directories(${CPP-NETLIB_SOURCE_DIR})
 
-file(GLOB_RECURSE CPP-NETLIB_HEADERS 
+file(GLOB_RECURSE CPP-NETLIB_HEADERS
     "${CPP-NETLIB_SOURCE_DIR}/boost/" "*.hpp")
 
 set(CPP-NETLIB_URI_SRCS uri/uri.cpp uri/schemes.cpp)

--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -45,7 +45,7 @@ if (OPENSSL_FOUND)
     target_link_libraries(cppnetlib-client-connections ${OPENSSL_LIBRARIES})
 endif ()
 if (Boost_FOUND)
-    target_link_libraries(cppnetlib-client-connections ${Boost_System_LIBRARY})
+    target_link_libraries(cppnetlib-client-connections ${Boost_LIBRARIES})
 endif ()
 install(TARGETS cppnetlib-client-connections
     EXPORT cppnetlibTargets


### PR DESCRIPTION
When adding cpp-netlib to my project with find_package() it is necessary to link against Boost libraries and include Boost headers files. Although this is already done by cpp-netlib.

This PR adds Boost libraries to the exported library list. It also adds ${Boost_INCLUDE_DIRS} to ${CPPNETLIB_INCLUDE_DIRS}. This way when I type

    find_package(cppnetlib REQUIRED)
    include_directories(${CPPNETLIB_INCLUDE_DIRS})

I do not need to take any more actions to make cppnetlib work in my project.