### PR TITLE
Add HTTP client options for SSL/TLS methods

### DIFF
--- a/boost/network/protocol/http/client/async_impl.hpp
+++ b/boost/network/protocol/http/client/async_impl.hpp
@@ -42,7 +42,8 @@ struct async_client
                optional<string_type> const& certificate_filename,
                optional<string_type> const& verify_path,
                optional<string_type> const& certificate_file,
-               optional<string_type> const& private_key_file)
+               optional<string_type> const& private_key_file,
+               optional<string_type> const& ciphers, long ssl_options)
       : connection_base(cache_resolved, follow_redirect, timeout),
         service_ptr(service.get()
                         ? service
@@ -54,6 +55,8 @@ struct async_client
         verify_path_(verify_path),
         certificate_file_(certificate_file),
         private_key_file_(private_key_file),
+        ciphers_(ciphers),
+        ssl_options_(ssl_options),
         always_verify_peer_(always_verify_peer) {
     connection_base::resolver_strand_.reset(
         new boost::asio::io_service::strand(service_));
@@ -79,7 +82,8 @@ struct async_client
     typename connection_base::connection_ptr connection_;
     connection_ = connection_base::get_connection(
         resolver_, request_, always_verify_peer_, certificate_filename_,
-        verify_path_, certificate_file_, private_key_file_);
+        verify_path_, certificate_file_, private_key_file_, ciphers_,
+        ssl_options_);
     return connection_->send_request(method, request_, get_body, callback,
                                      generator);
   }
@@ -93,6 +97,8 @@ struct async_client
   optional<string_type> verify_path_;
   optional<string_type> certificate_file_;
   optional<string_type> private_key_file_;
+  optional<string_type> ciphers_;
+  long ssl_options_;
   bool always_verify_peer_;
 };
 }  // namespace impl

--- a/boost/network/protocol/http/client/connection/async_base.hpp
+++ b/boost/network/protocol/http/client/connection/async_base.hpp
@@ -43,7 +43,9 @@ struct async_connection_base {
       optional<string_type> certificate_filename = optional<string_type>(),
       optional<string_type> const &verify_path = optional<string_type>(),
       optional<string_type> certificate_file = optional<string_type>(),
-      optional<string_type> private_key_file = optional<string_type>()) {
+      optional<string_type> private_key_file = optional<string_type>(),
+      optional<string_type> ciphers = optional<string_type>(),
+      long ssl_options = 0) {
     typedef http_async_connection<Tag, version_major, version_minor>
         async_connection;
     typedef typename delegate_factory<Tag>::type delegate_factory_type;
@@ -53,7 +55,7 @@ struct async_connection_base {
         delegate_factory_type::new_connection_delegate(
             resolver.get_io_service(), https, always_verify_peer,
             certificate_filename, verify_path, certificate_file,
-            private_key_file)));
+            private_key_file, ciphers, ssl_options)));
     BOOST_ASSERT(temp.get() != 0);
     return temp;
   }

--- a/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
+++ b/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
@@ -35,13 +35,14 @@ struct connection_delegate_factory {
       asio::io_service& service, bool https, bool always_verify_peer,
       optional<string_type> certificate_filename,
       optional<string_type> verify_path, optional<string_type> certificate_file,
-      optional<string_type> private_key_file) {
+      optional<string_type> private_key_file, optional<string_type> ciphers,
+      long ssl_options) {
     connection_delegate_ptr delegate;
     if (https) {
 #ifdef BOOST_NETWORK_ENABLE_HTTPS
-      delegate.reset(new ssl_delegate(service, always_verify_peer,
-                                      certificate_filename, verify_path,
-                                      certificate_file, private_key_file));
+      delegate.reset(new ssl_delegate(
+          service, always_verify_peer, certificate_filename, verify_path,
+          certificate_file, private_key_file, ciphers, ssl_options));
 #else
       BOOST_THROW_EXCEPTION(std::runtime_error("HTTPS not supported."));
 #endif /* BOOST_NETWORK_ENABLE_HTTPS */

--- a/boost/network/protocol/http/client/connection/ssl_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.hpp
@@ -26,7 +26,8 @@ struct ssl_delegate : connection_delegate,
                optional<std::string> certificate_filename,
                optional<std::string> verify_path,
                optional<std::string> certificate_file,
-               optional<std::string> private_key_file);
+               optional<std::string> private_key_file,
+               optional<std::string> ciphers, long ssl_options);
 
   virtual void connect(asio::ip::tcp::endpoint &endpoint, std::string host,
                        function<void(system::error_code const &)> handler);
@@ -45,6 +46,8 @@ struct ssl_delegate : connection_delegate,
   optional<std::string> verify_path_;
   optional<std::string> certificate_file_;
   optional<std::string> private_key_file_;
+  optional<std::string> ciphers_;
+  long ssl_options_;
   scoped_ptr<asio::ssl::context> context_;
   scoped_ptr<asio::ssl::stream<asio::ip::tcp::socket> > socket_;
   bool always_verify_peer_;

--- a/boost/network/protocol/http/client/connection/ssl_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.ipp
@@ -32,7 +32,7 @@ void boost::network::http::impl::ssl_delegate::connect(
     asio::ip::tcp::endpoint &endpoint, std::string host,
     function<void(system::error_code const &)> handler) {
   context_.reset(
-      new asio::ssl::context(service_, asio::ssl::context::tlsv1_client));
+      new asio::ssl::context(service_, asio::ssl::context::sslv23_client));
   if (ciphers_) {
     ::SSL_CTX_set_cipher_list(context_->native_handle(), ciphers_->c_str());
   }
@@ -47,7 +47,7 @@ void boost::network::http::impl::ssl_delegate::connect(
   } else {
     if (always_verify_peer_) {
       context_->set_verify_mode(asio::ssl::context::verify_peer);
-	   	// use openssl default verify paths.  uses openssl environment variables
+      // use openssl default verify paths.  uses openssl environment variables
       // SSL_CERT_DIR, SSL_CERT_FILE
       context_->set_default_verify_paths();
 	 } else

--- a/boost/network/protocol/http/client/connection/sync_base.hpp
+++ b/boost/network/protocol/http/client/connection/sync_base.hpp
@@ -245,14 +245,18 @@ struct sync_connection_base {
   // optional
   // ranges
   static sync_connection_base<Tag, version_major, version_minor>*
-  new_connection(
-      resolver_type& resolver, resolver_function_type resolve, bool https,
-      bool always_verify_peer, int timeout,
-      optional<string_type> const& certificate_filename =
-          optional<string_type>(),
-      optional<string_type> const& verify_path = optional<string_type>(),
-      optional<string_type> const& certificate_file = optional<string_type>(),
-      optional<string_type> const& private_key_file = optional<string_type>()) {
+      new_connection(
+          resolver_type& resolver, resolver_function_type resolve, bool https,
+          bool always_verify_peer, int timeout,
+          optional<string_type> const& certificate_filename =
+              optional<string_type>(),
+          optional<string_type> const& verify_path = optional<string_type>(),
+          optional<string_type> const& certificate_file =
+              optional<string_type>(),
+          optional<string_type> const& private_key_file =
+              optional<string_type>(),
+          optional<string_type> const& ciphers = optional<string_type>(),
+          long ssl_options = 0) {
     if (https) {
 #ifdef BOOST_NETWORK_ENABLE_HTTPS
       return dynamic_cast<
@@ -260,7 +264,7 @@ struct sync_connection_base {
           new https_sync_connection<Tag, version_major, version_minor>(
               resolver, resolve, always_verify_peer, timeout,
               certificate_filename, verify_path, certificate_file,
-              private_key_file));
+              private_key_file, ciphers, ssl_options));
 #else
       throw std::runtime_error("HTTPS not supported.");
 #endif

--- a/boost/network/protocol/http/client/connection/sync_ssl.hpp
+++ b/boost/network/protocol/http/client/connection/sync_ssl.hpp
@@ -56,7 +56,9 @@ struct https_sync_connection
           optional<string_type>(),
       optional<string_type> const& verify_path = optional<string_type>(),
       optional<string_type> const& certificate_file = optional<string_type>(),
-      optional<string_type> const& private_key_file = optional<string_type>())
+      optional<string_type> const& private_key_file = optional<string_type>(),
+      optional<string_type> const& ciphers = optional<string_type>(),
+      long ssl_options = 0)
       : connection_base(),
         timeout_(timeout),
         timer_(resolver.get_io_service()),
@@ -65,6 +67,12 @@ struct https_sync_connection
         context_(resolver.get_io_service(),
                  boost::asio::ssl::context::sslv23_client),
         socket_(resolver.get_io_service(), context_) {
+    if (ciphers) {
+      ::SSL_CTX_set_cipher_list(context_.native_handle(), ciphers->c_str());
+    }
+    if (ssl_options != 0) {
+      context_.set_options(ssl_options);
+    }
     if (certificate_filename || verify_path) {
       context_.set_verify_mode(boost::asio::ssl::context::verify_peer);
       // FIXME make the certificate filename and verify path parameters

--- a/boost/network/protocol/http/client/facade.hpp
+++ b/boost/network/protocol/http/client/facade.hpp
@@ -162,8 +162,8 @@ struct basic_client_facade {
         options.cache_resolved(), options.follow_redirects(),
         options.always_verify_peer(), options.openssl_certificate(),
         options.openssl_verify_path(), options.openssl_certificate_file(),
-        options.openssl_private_key_file(), options.io_service(),
-        options.timeout()));
+        options.openssl_private_key_file(), options.openssl_ciphers(),
+        options.openssl_options(), options.io_service(), options.timeout()));
   }
 };
 

--- a/boost/network/protocol/http/client/options.hpp
+++ b/boost/network/protocol/http/client/options.hpp
@@ -102,7 +102,7 @@ struct client_options {
   }
 
   client_options& openssl_options(long o) {
-    openssl_options_ ^= o;
+    openssl_options_ = o;
     return *this;
   }
 

--- a/boost/network/protocol/http/client/options.hpp
+++ b/boost/network/protocol/http/client/options.hpp
@@ -27,6 +27,8 @@ struct client_options {
         openssl_verify_path_(),
         openssl_certificate_file_(),
         openssl_private_key_file_(),
+        openssl_ciphers_(),
+        openssl_options_(0),
         io_service_(),
         always_verify_peer_(false),
         timeout_(0) {}
@@ -38,6 +40,8 @@ struct client_options {
         openssl_verify_path_(other.openssl_verify_path_),
         openssl_certificate_file_(other.openssl_certificate_file_),
         openssl_private_key_file_(other.openssl_private_key_file_),
+        openssl_ciphers_(other.openssl_ciphers_),
+        openssl_options_(other.openssl_options_),
         io_service_(other.io_service_),
         always_verify_peer_(other.always_verify_peer_),
         timeout_(other.timeout_) {}
@@ -55,6 +59,8 @@ struct client_options {
     swap(openssl_verify_path_, other.openssl_verify_path_);
     swap(openssl_certificate_file_, other.openssl_certificate_file_);
     swap(openssl_private_key_file_, other.openssl_private_key_file_);
+    swap(openssl_ciphers_, other.openssl_ciphers_);
+    swap(openssl_options_, other.openssl_options_);
     swap(io_service_, other.io_service_);
     swap(always_verify_peer_, other.always_verify_peer_);
     swap(timeout_, other.timeout_);
@@ -87,6 +93,16 @@ struct client_options {
 
   client_options& openssl_private_key_file(string_type const& v) {
     openssl_private_key_file_ = v;
+    return *this;
+  }
+
+  client_options& openssl_ciphers(string_type const& v) {
+    openssl_ciphers_ = v;
+    return *this;
+  }
+
+  client_options& openssl_options(long o) {
+    openssl_options_ ^= o;
     return *this;
   }
 
@@ -125,6 +141,12 @@ struct client_options {
     return openssl_private_key_file_;
   }
 
+  boost::optional<string_type> openssl_ciphers() const {
+    return openssl_ciphers_;
+  }
+
+  long openssl_options() const { return openssl_options_; }
+
   boost::shared_ptr<boost::asio::io_service> io_service() const {
     return io_service_;
   }
@@ -140,6 +162,8 @@ struct client_options {
   boost::optional<string_type> openssl_verify_path_;
   boost::optional<string_type> openssl_certificate_file_;
   boost::optional<string_type> openssl_private_key_file_;
+  boost::optional<string_type> openssl_ciphers_;
+  long openssl_options_;
   boost::shared_ptr<boost::asio::io_service> io_service_;
   bool always_verify_peer_;
   int timeout_;

--- a/boost/network/protocol/http/client/pimpl.hpp
+++ b/boost/network/protocol/http/client/pimpl.hpp
@@ -71,11 +71,12 @@ struct basic_client_impl
                     optional<string_type> const& verify_path,
                     optional<string_type> const& certificate_file,
                     optional<string_type> const& private_key_file,
+                    optional<string_type> const& ciphers, long ssl_options,
                     boost::shared_ptr<boost::asio::io_service> service,
                     int timeout)
       : base_type(cache_resolved, follow_redirect, always_verify_peer, timeout,
                   service, certificate_filename, verify_path, certificate_file,
-                  private_key_file) {}
+                  private_key_file, ciphers, ssl_options) {}
 
   ~basic_client_impl() {}
 };

--- a/boost/network/protocol/http/client/sync_impl.hpp
+++ b/boost/network/protocol/http/client/sync_impl.hpp
@@ -44,6 +44,8 @@ struct sync_client
   optional<string_type> verify_path_;
   optional<string_type> certificate_file_;
   optional<string_type> private_key_file_;
+  optional<string_type> ciphers_;
+  long ssl_options_;
   bool always_verify_peer_;
 
   sync_client(
@@ -53,7 +55,9 @@ struct sync_client
           optional<string_type>(),
       optional<string_type> const& verify_path = optional<string_type>(),
       optional<string_type> const& certificate_file = optional<string_type>(),
-      optional<string_type> const& private_key_file = optional<string_type>())
+      optional<string_type> const& private_key_file = optional<string_type>(),
+      optional<string_type> const& ciphers = optional<string_type>(),
+      long ssl_options = 0)
       : connection_base(cache_resolved, follow_redirect, timeout),
         service_ptr(service.get() ? service
                                   : make_shared<boost::asio::io_service>()),
@@ -63,6 +67,8 @@ struct sync_client
         verify_path_(verify_path),
         certificate_file_(certificate_file),
         private_key_file_(private_key_file),
+        ciphers_(ciphers),
+        ssl_options_(ssl_options),
         always_verify_peer_(always_verify_peer) {}
 
   ~sync_client() {
@@ -79,7 +85,7 @@ struct sync_client
     typename connection_base::connection_ptr connection_;
     connection_ = connection_base::get_connection(
         resolver_, request_, always_verify_peer_, certificate_filename_,
-        verify_path_, certificate_file_, private_key_file_);
+        verify_path_, certificate_file_, private_key_file_, ciphers_);
     return connection_->send_request(method, request_, get_body, callback,
                                      generator);
   }

--- a/boost/network/protocol/http/policies/async_connection.hpp
+++ b/boost/network/protocol/http/policies/async_connection.hpp
@@ -42,13 +42,15 @@ struct async_connection_policy : resolver_policy<Tag>::type {
                     optional<string_type> const& certificate_filename,
                     optional<string_type> const& verify_path,
                     optional<string_type> const& certificate_file,
-                    optional<string_type> const& private_key_file) {
+                    optional<string_type> const& private_key_file,
+                    optional<string_type> const& ciphers, long ssl_options) {
       pimpl = impl::async_connection_base<
           Tag, version_major,
           version_minor>::new_connection(resolve, resolver, follow_redirect,
                                          always_verify_peer, https, timeout,
                                          certificate_filename, verify_path,
-                                         certificate_file, private_key_file);
+                                         certificate_file, private_key_file,
+                                         ciphers, ssl_options);
     }
 
     basic_response<Tag> send_request(string_type const& method,
@@ -72,7 +74,9 @@ struct async_connection_policy : resolver_policy<Tag>::type {
           optional<string_type>(),
       optional<string_type> const& verify_path = optional<string_type>(),
       optional<string_type> const& certificate_file = optional<string_type>(),
-      optional<string_type> const& private_key_file = optional<string_type>()) {
+      optional<string_type> const& private_key_file = optional<string_type>(),
+      optional<string_type> const& ciphers = optional<string_type>(),
+      long ssl_options = 0) {
     string_type protocol_ = protocol(request_);
     connection_ptr connection_(new connection_impl(
         follow_redirect_, always_verify_peer,
@@ -81,7 +85,8 @@ struct async_connection_policy : resolver_policy<Tag>::type {
                     this, boost::arg<1>(), boost::arg<2>(), boost::arg<3>(),
                     boost::arg<4>()),
         resolver, boost::iequals(protocol_, string_type("https")), timeout_,
-        certificate_filename, verify_path, certificate_file, private_key_file));
+        certificate_filename, verify_path, certificate_file, private_key_file,
+        ciphers, ssl_options));
     return connection_;
   }
 

--- a/boost/network/protocol/http/policies/simple_connection.hpp
+++ b/boost/network/protocol/http/policies/simple_connection.hpp
@@ -48,9 +48,10 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
             optional<string_type>(),
         optional<string_type> const& verify_path = optional<string_type>(),
         optional<string_type> const& certificate_file = optional<string_type>(),
-        optional<string_type> const& private_key_file = optional<string_type>())
+        optional<string_type> const& private_key_file = optional<string_type>(),
+        optional<string_type> const& ciphers = optional<string_type>(),
+        long ssl_options = 0)
         : pimpl(), follow_redirect_(follow_redirect) {
-
       // TODO(dberris): review parameter necessity.
       (void)hostname;
       (void)port;
@@ -60,7 +61,8 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
           version_minor>::new_connection(resolver, resolve, https,
                                          always_verify_peer, timeout,
                                          certificate_filename, verify_path,
-                                         certificate_file, private_key_file));
+                                         certificate_file, private_key_file,
+                                         ciphers, ssl_options));
     }
 
     basic_response<Tag> send_request(string_type const& method,
@@ -119,7 +121,9 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
           optional<string_type>(),
       optional<string_type> const& verify_path = optional<string_type>(),
       optional<string_type> const& certificate_file = optional<string_type>(),
-      optional<string_type> const& private_key_file = optional<string_type>()) {
+      optional<string_type> const& private_key_file = optional<string_type>(),
+      optional<string_type> const& ciphers = optional<string_type>(),
+      long ssl_options = 0) {
     connection_ptr connection_(new connection_impl(
         resolver, follow_redirect_, always_verify_peer, request_.host(),
         lexical_cast<string_type>(request_.port()),
@@ -127,7 +131,8 @@ struct simple_connection_policy : resolver_policy<Tag>::type {
                                               version_minor>::resolve,
                     this, boost::arg<1>(), boost::arg<2>(), boost::arg<3>()),
         boost::iequals(request_.protocol(), string_type("https")), timeout_,
-        certificate_filename, verify_path, certificate_file, private_key_file));
+        certificate_filename, verify_path, certificate_file, private_key_file,
+        ciphers, ssl_options));
     return connection_;
   }
 


### PR DESCRIPTION
Currently the netlib HTTP client only allows SSLv23 clients without control over ciphers or protocol restrictions.

This pushes the ASIO ssl_options and OpenSSL cipher suite selection into the `client_options` struct. So the client API may implement something like:
```cpp
  http::client::options options;
  options.follow_redirects(true).always_verify_peer(true);
  options.openssl_ciphers("ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256");
  options.openssl_options(SSL_OP_NO_SSLv3 | SSL_OP_NO_SSLv2 | SSL_OP_ALL);
  http::client client(options);
```

I'm unsure if I caught all possible default arguments in the sync/async abstractions/workflows. ;)

Edit/update: This used to push the SSL/TLS method through to ASIO, but options and ciphers are much more flexible!