### PR TITLE
Fixed URI encode_char bug #362

### DIFF
--- a/boost/network/uri/encode.hpp
+++ b/boost/network/uri/encode.hpp
@@ -115,7 +115,7 @@ void encode_char(CharT in, OutputIterator &out) {
       break;
     default:
       out++ = '%';
-      out++ = hex_to_letter(in >> 4);
+      out++ = hex_to_letter((in >> 4) & 0x0f);
       out++ = hex_to_letter(in & 0x0f);
       ;
   }

--- a/libs/network/test/uri/uri_encoding_test.cpp
+++ b/libs/network/test/uri/uri_encoding_test.cpp
@@ -29,3 +29,21 @@ BOOST_AUTO_TEST_CASE(decoding_test) {
   uri::decode(encoded, std::back_inserter(instance));
   BOOST_CHECK_EQUAL(instance, unencoded);
 }
+
+BOOST_AUTO_TEST_CASE(encoding_multibyte_test) {
+  const std::string unencoded("한글 테스트");
+  const std::string encoded("%ED%95%9C%EA%B8%80%20%ED%85%8C%EC%8A%A4%ED%8A%B8");
+
+  std::string instance;
+  uri::encode(unencoded, std::back_inserter(instance));
+  BOOST_CHECK_EQUAL(instance, encoded);
+}
+
+BOOST_AUTO_TEST_CASE(decoding_multibyte_test) {
+  const std::string unencoded("한글 테스트");
+  const std::string encoded("%ED%95%9C%EA%B8%80%20%ED%85%8C%EC%8A%A4%ED%8A%B8");
+
+  std::string instance;
+  uri::decode(encoded, std::back_inserter(instance));
+  BOOST_CHECK_EQUAL(instance, unencoded);
+}


### PR DESCRIPTION
#362 
* fix the 'boost::network::uri::encode' functions - Arithmetic shift problem
* add testcase for multibyte string in 'boost::network::uri::encode' function