### PR TITLE
Fix test failures in os x

### DIFF
--- a/libs/network/test/CMakeLists.txt
+++ b/libs/network/test/CMakeLists.txt
@@ -39,5 +39,8 @@ if (Boost_FOUND)
             ${CPP-NETLIB_BINARY_DIR}/tests/cpp-netlib-${test})
     endforeach (test)
 
+    # Also copy the server directory to the root of the build directory.
+    file(COPY server DESTINATION ${CPP-NETLIB_BINARY_DIR}/libs/network/test/)
+
 endif()
 

--- a/libs/network/test/http/client_get_timeout_test.cpp
+++ b/libs/network/test/http/client_get_timeout_test.cpp
@@ -5,6 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_TEST_MODULE HTTP Client Get Timeout Test
+#include <cstdlib>
 #include <boost/network/include/http/client.hpp>
 #include <boost/test/unit_test.hpp>
 #include "client_types.hpp"
@@ -12,13 +13,17 @@
 
 struct localhost_server_fixture {
   localhost_server_fixture() {
-    if (!server.start())
+    if (!server.start()) {
       std::cout << "Failed to start HTTP server for test!" << std::endl;
+      std::abort();
+    }
   }
 
   ~localhost_server_fixture() {
-    if (!server.stop())
+    if (!server.stop()) {
       std::cout << "Failed to stop HTTP server for test!" << std::endl;
+      std::abort();
+    }
   }
 
   http_test_server server;


### PR DESCRIPTION
Building from outside the source distribution causes the get_client_test to break and fail because it can't find the local server implementation. This fixes the problem by copying the server files over to the same directory where the tests are being built.