### PR TITLE
Remove user-declared default, copy and move constructors

### DIFF
--- a/http/src/network/http/v2/client/response.hpp
+++ b/http/src/network/http/v2/client/response.hpp
@@ -61,23 +61,6 @@ public:
   typedef headers_type::const_iterator const_headers_iterator;
 
   /**
-   * \brief Constructor.
-   */
-  response() = default;
-
-  /**
-   * \brief Copy constructor.
-   * \param other The other response object.
-   */
-  response(const response &other) = default;
-
-  /**
-   * \brief Move constructor.
-   * \param other The other response object.
-   */
-  response(response &&other) noexcept = default;
-
-  /**
    * \brief Swap function.
    * \param other The other response object.
    */


### PR DESCRIPTION
The defaulted move constructor prevents implicit declaration of the copy assignment operator, which results in compiler errors since std::promise requires it.

All 3 user-declared methods removed here are implicitly declared by the compiler anyway, so no need to default them in the first place.

Relates to #547