### PR TITLE
Boost include directories are now tied to targets directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 before_install:
     - sudo add-apt-repository ppa:apokluda/boost1.53 --yes
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test --yes # libstdc++-4.8
+    - sudo add-apt-repository ppa:george-edison55/cmake-3.x --yes
     - if [ "${CXX}" == "clang++" ]; then sudo add-apt-repository --yes ppa:h-rayflood/llvm; fi # clang++-3.2
     - sudo apt-get update
 
@@ -23,6 +24,7 @@ install:
     - sudo apt-get install libboost-system1.53-dev
     - sudo apt-get install libboost-regex1.53-dev
     - sudo apt-get install libboost-filesystem1.53-dev
+    - sudo apt-get install cmake
 
 before_script:
     # update compilers

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 before_install:
     - sudo add-apt-repository ppa:apokluda/boost1.53 --yes
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test --yes # libstdc++-4.8
-    - sudo add-apt-repository ppa:george-edison55/cmake-3.x --yes
     - if [ "${CXX}" == "clang++" ]; then sudo add-apt-repository --yes ppa:h-rayflood/llvm; fi # clang++-3.2
     - sudo apt-get update
 
@@ -24,7 +23,7 @@ install:
     - sudo apt-get install libboost-system1.53-dev
     - sudo apt-get install libboost-regex1.53-dev
     - sudo apt-get install libboost-filesystem1.53-dev
-    - sudo apt-get install cmake
+    - wget -qO- http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz | tar xvz && sudo cp -fR cmake-3.3.2-Linux-x86_64/* /usr
 
 before_script:
     # update compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(CPP-NETLIB)
 
 option( CPP-NETLIB_BUILD_SHARED_LIBS "Build cpp-netlib as shared libraries." OFF )
@@ -84,7 +84,6 @@ endif(MSVC)
 if (WIN32)
   add_definitions(-D_WIN32_WINNT=0x0501)
 endif(WIN32)
-include_directories(${Boost_INCLUDE_DIRS})
 
 message(STATUS "CPP-NETLIB options selected:")
 message(STATUS "  CPP-NETLIB_BUILD_SHARED_LIBS:      ${CPP-NETLIB_BUILD_SHARED_LIBS}\t(Build cpp-netlib as shared libraries: OFF, ON)")
@@ -157,7 +156,7 @@ if (DOXYGEN_FOUND)
 endif(DOXYGEN_FOUND)
 
 if(CPP-NETLIB_BUILD_SINGLE_LIB)
-  include_directories(
+  set( all_include_dirs
     ${CMAKE_CURRENT_SOURCE_DIR}/config/src
     ${CMAKE_CURRENT_SOURCE_DIR}/concurrency/src
     ${CMAKE_CURRENT_SOURCE_DIR}/http/src
@@ -194,4 +193,5 @@ if(CPP-NETLIB_BUILD_SINGLE_LIB)
     ${CPP-NETLIB_CONCURRENCY_SRCS}
   )
   target_link_libraries(cppnetlib ${Boost_LIBRARIES})
+  target_include_directories(cppnetlib PUBLIC ${all_include_dirs} ${Boost_INCLUDE_DIRS})
 endif()

--- a/README.rst
+++ b/README.rst
@@ -53,13 +53,13 @@ Building with CMake
 ~~~~~~~~~~~~~~~~~~~
 
 To build the libraries and run the tests with CMake, you will need to
-have CMake version 2.8.10 or higher installed appropriately in your
+have CMake version 3.0 or higher installed appropriately in your
 system.
 
 ::
 
     $ cmake --version
-    cmake version 2.8.10
+    cmake version 3.2.2
 
 Inside the cpp-netlib directory, you can issue the following statements to
 configure and generate the Makefiles, and build the tests::

--- a/concurrency/src/CMakeLists.txt
+++ b/concurrency/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CPP-NETLIB_CONCURRENCY_SRCS
 
 if(NOT CPP-NETLIB_BUILD_SINGLE_LIB)
   add_library(network-concurrency ${CPP-NETLIB_CONCURRENCY_SRCS})
+  target_include_directories(network-concurrency PUBLIC ${Boost_INCLUDE_DIRS})
 endif()
 
 # prepend current directory to make paths absolute

--- a/concurrency/test/CMakeLists.txt
+++ b/concurrency/test/CMakeLists.txt
@@ -14,6 +14,7 @@ if (CPP-NETLIB_BUILD_TESTS)
     ${Boost_LIBRARIES}
     ${GTEST_BOTH_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT})
+  target_include_directories(cpp-netlib-thread_pool_test PUBLIC ${Boost_INCLUDE_DIRS})
   set_target_properties(cpp-netlib-thread_pool_test PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/tests)
   add_test(cpp-netlib-thread_pool_test

--- a/contrib/http_examples/CMakeLists.txt
+++ b/contrib/http_examples/CMakeLists.txt
@@ -33,5 +33,6 @@ foreach(example ${EXAMPLES})
     ${ICU_LIBRARIES} ${ICU_I18N_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     )
+  target_include_directories(${example} PUBLIC ${Boost_INCLUDE_DIRS})
   set_target_properties(${example} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/example)
 endforeach(example)

--- a/http/src/CMakeLists.txt
+++ b/http/src/CMakeLists.txt
@@ -28,6 +28,7 @@ if(NOT CPP-NETLIB_BUILD_SINGLE_LIB)
   target_link_libraries(network-http-message
     ${Boost_LIBRARIES}
     network-message)
+  target_include_directories(network-http-message PUBLIC ${Boost_INCLUDE_DIRS})
 endif()
 
 set(CPP-NETLIB_HTTP_MESSAGE_WRAPPERS_SRCS
@@ -35,6 +36,7 @@ set(CPP-NETLIB_HTTP_MESSAGE_WRAPPERS_SRCS
 
 if(NOT CPP-NETLIB_BUILD_SINGLE_LIB)
   add_library(network-http-message-wrappers ${CPP-NETLIB_HTTP_MESSAGE_WRAPPERS_SRCS})
+  target_include_directories(network-http-message-wrappers PUBLIC ${Boost_INCLUDE_DIRS})
 endif()
 
 set(CPP-NETLIB_CONSTANTS_SRCS
@@ -42,6 +44,7 @@ set(CPP-NETLIB_CONSTANTS_SRCS
 
 if(NOT CPP-NETLIB_BUILD_SINGLE_LIB)
   add_library(network-constants ${CPP-NETLIB_CONSTANTS_SRCS})
+  target_include_directories(network-constants PUBLIC ${Boost_INCLUDE_DIRS})
 endif()
 
 # Server implementation files.
@@ -52,6 +55,7 @@ set(CPP-NETLIB_HTTP_SERVER_SRCS
 
 if (NOT CPP-NETLIB_BUILD_SINGLE_LIB)
   add_library(network-http-server ${CPP-NETLIB_HTTP_SERVER_SRCS})
+  target_include_directories(network-http-server PUBLIC ${Boost_INCLUDE_DIRS})
 endif()
 
 # HTTP client
@@ -64,6 +68,7 @@ target_link_libraries(network-http-v2-client
   ${Boost_LIBRARIES}
   network-uri
   )
+target_include_directories(network-http-v2-client PUBLIC ${Boost_INCLUDE_DIRS})
 if (OPENSSL_FOUND)
   target_link_libraries(network-http-v2-client ${OPENSSL_LIBRARIES})
 endif()

--- a/http/test/CMakeLists.txt
+++ b/http/test/CMakeLists.txt
@@ -58,6 +58,7 @@ if (CPP-NETLIB_BUILD_TESTS)
       ${ICU_LIBRARIES} ${ICU_I18N_LIBRARIES}
       ${CMAKE_THREAD_LIBS_INIT}
       ${CPPNETLIB_LIBRARIES} )
+    target_include_directories(cpp-netlib-http-${test} PUBLIC ${Boost_INCLUDE_DIRS})
     set_target_properties(cpp-netlib-http-${test}
       PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/tests)
     add_test(cpp-netlib-http-${test}
@@ -91,6 +92,7 @@ if (CPP-NETLIB_BUILD_TESTS)
       ${GTEST_BOTH_LIBRARIES}
       ${CMAKE_THREAD_LIBS_INIT}
       ${CPPNETLIB_SERVER_LIBRARIES} )
+    target_include_directories(cpp-netlib-http-${test} PUBLIC ${Boost_INCLUDE_DIRS})
     set_target_properties(cpp-netlib-http-${test} PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/tests)
     add_test(cpp-netlib-http-${test}

--- a/http/test/v2/client/features/CMakeLists.txt
+++ b/http/test/v2/client/features/CMakeLists.txt
@@ -27,6 +27,7 @@ foreach(test ${CPP-NETLIB_CLIENT_TESTS})
     ${ICU_LIBRARIES} ${ICU_I18N_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     )
+  target_include_directories(cpp-netlib-http-v2-${test} PUBLIC ${Boost_INCLUDE_DIRS})
   set_target_properties(cpp-netlib-http-v2-${test}
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/tests)
   add_test(cpp-netlib-http-v2-${test}

--- a/http/test/v2/client/units/CMakeLists.txt
+++ b/http/test/v2/client/units/CMakeLists.txt
@@ -29,6 +29,7 @@ foreach(test ${CPP-NETLIB_CLIENT_TESTS})
     ${ICU_LIBRARIES} ${ICU_I18N_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     )
+  target_include_directories(cpp-netlib-http-v2-${test} PUBLIC ${Boost_INCLUDE_DIRS})
   set_target_properties(cpp-netlib-http-v2-${test}
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/tests)
   add_test(cpp-netlib-http-v2-${test}

--- a/logging/test/CMakeLists.txt
+++ b/logging/test/CMakeLists.txt
@@ -28,6 +28,7 @@ if (CPP-NETLIB_BUILD_TESTS)
     add_executable(cpp-netlib-${test} ${test}.cpp)
     target_link_libraries(cpp-netlib-${test}
       ${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} ${link_cppnetlib_lib})
+    target_include_directories(cpp-netlib-${test} PUBLIC ${Boost_INCLUDE_DIRS})
     set_target_properties(cpp-netlib-${test}
       PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CPP-NETLIB_BINARY_DIR}/tests)
     add_test(cpp-netlib-${test}

--- a/message/src/CMakeLists.txt
+++ b/message/src/CMakeLists.txt
@@ -11,17 +11,20 @@ set(CPP-NETLIB_MESSAGE_SRCS
     message.cpp)
 
 add_library(network-message ${CPP-NETLIB_MESSAGE_SRCS})
+target_include_directories(network-message PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(network-message network-uri)
 
 set(CPP-NETLIB_MESSAGE_DIRECTIVES_SRCS
     directives.cpp)
 
 add_library(network-message-directives ${CPP-NETLIB_MESSAGE_DIRECTIVES_SRCS})
+target_include_directories(network-message-directives PUBLIC ${Boost_INCLUDE_DIRS})
 
 set(CPP-NETLIB_MESSAGE_WRAPPERS_SRCS
     wrappers.cpp)
 
 add_library(network-message-wrappers ${CPP-NETLIB_MESSAGE_WRAPPERS_SRCS})
+target_include_directories(network-message-wrappers PUBLIC ${Boost_INCLUDE_DIRS})
 
 # prepend current directory to make paths absolute
 prependToElements( "${CMAKE_CURRENT_SOURCE_DIR}/"


### PR DESCRIPTION
Boost is required for cppnetlib & related projects. Thus, it should transitively provided include directories to its own source as well as the include directories to its dependencies (Boost in this case).

That way if there are other CMake targets that depend on cppnetlib but not Boost directly, it will still be able to compile cppnetlib headers that include boost headers.

The include directories are tied to respective targets via the new target_include_directories() CMake command. This requires a newer version of CMake (v3.0 minimum).