### PR TITLE
Setting source port

### DIFF
--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -95,10 +95,12 @@ struct http_async_connection
     this->method = method;
     boost::uint16_t port_ = port(request);
 	string_type host_ = host(request);
+	boost::uint16_t source_port = request.getSourcePort();
+
     resolve_(resolver_, host_, port_,
              request_strand_.wrap(boost::bind(
                  &this_type::handle_resolved, this_type::shared_from_this(),
-                 host_, port_, get_body, callback,
+                 host_, port_, source_port, get_body, callback,
                  generator, boost::arg<1>(), boost::arg<2>())));
     if (timeout_ > 0) {
       timer_.expires_from_now(boost::posix_time::seconds(timeout_));
@@ -129,7 +131,7 @@ struct http_async_connection
     is_timedout_ = true;
   }
 
-  void handle_resolved(string_type host, boost::uint16_t port, bool get_body,
+  void handle_resolved(string_type host, boost::uint16_t port, boost::uint16_t source_port, bool get_body,
                        body_callback_function_type callback,
                        body_generator_function_type generator,
                        boost::system::error_code const& ec,
@@ -141,10 +143,10 @@ struct http_async_connection
       resolver_iterator iter = boost::begin(endpoint_range);
       asio::ip::tcp::endpoint endpoint(iter->endpoint().address(), port);
       delegate_->connect(
-          endpoint, host,
+          endpoint, host, source_port,
           request_strand_.wrap(boost::bind(
               &this_type::handle_connected, this_type::shared_from_this(), host,
-              port, get_body, callback, generator,
+              port, source_port, get_body, callback, generator,
               std::make_pair(++iter, resolver_iterator()),
               placeholders::error)));
     } else {
@@ -154,7 +156,7 @@ struct http_async_connection
     }
   }
 
-  void handle_connected(string_type host, boost::uint16_t port, bool get_body,
+  void handle_connected(string_type host, boost::uint16_t port, boost::uint16_t source_port, bool get_body,
                         body_callback_function_type callback,
                         body_generator_function_type generator,
                         resolver_iterator_pair endpoint_range,
@@ -174,10 +176,10 @@ struct http_async_connection
         resolver_iterator iter = boost::begin(endpoint_range);
         asio::ip::tcp::endpoint endpoint(iter->endpoint().address(), port);
         delegate_->connect(
-            endpoint, host,
+            endpoint, host, source_port,
             request_strand_.wrap(boost::bind(
                 &this_type::handle_connected, this_type::shared_from_this(),
-                host, port, get_body, callback, generator,
+                host, port, source_port, get_body, callback, generator,
                 std::make_pair(++iter, resolver_iterator()),
                 placeholders::error)));
       } else {

--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -95,7 +95,7 @@ struct http_async_connection
     this->method = method;
     boost::uint16_t port_ = port(request);
 	string_type host_ = host(request);
-	boost::uint16_t source_port = request.getSourcePort();
+	boost::uint16_t source_port = request.source_port();
 
     resolve_(resolver_, host_, port_,
              request_strand_.wrap(boost::bind(

--- a/boost/network/protocol/http/client/connection/connection_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/connection_delegate.hpp
@@ -13,7 +13,7 @@ namespace http {
 namespace impl {
 
 struct connection_delegate {
-  virtual void connect(asio::ip::tcp::endpoint &endpoint, std::string host,
+  virtual void connect(asio::ip::tcp::endpoint &endpoint, std::string host, boost::uint16_t source_port,
                        function<void(system::error_code const &)> handler) = 0;
   virtual void write(
       asio::streambuf &command_streambuf,

--- a/boost/network/protocol/http/client/connection/normal_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/normal_delegate.hpp
@@ -19,7 +19,7 @@ namespace impl {
 struct normal_delegate : connection_delegate {
   normal_delegate(asio::io_service &service);
 
-  virtual void connect(asio::ip::tcp::endpoint &endpoint, std::string host,
+  virtual void connect(asio::ip::tcp::endpoint &endpoint, std::string host, boost::uint16_t source_port,
                        function<void(system::error_code const &)> handler);
   virtual void write(
       asio::streambuf &command_streambuf,

--- a/boost/network/protocol/http/client/connection/normal_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/normal_delegate.ipp
@@ -19,13 +19,13 @@ boost::network::http::impl::normal_delegate::normal_delegate(
     : service_(service) {}
 
 void boost::network::http::impl::normal_delegate::connect(
-    asio::ip::tcp::endpoint &endpoint, std::string host,
+    asio::ip::tcp::endpoint &endpoint, std::string host, boost::uint16_t source_port, 
     function<void(system::error_code const &)> handler) {
 
   // TODO(dberris): review parameter necessity.
   (void)host;
-
-  socket_.reset(new asio::ip::tcp::socket(service_));
+ 
+  socket_.reset(new asio::ip::tcp::socket(service_, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), source_port)));
   socket_->async_connect(endpoint, handler);
 }
 

--- a/boost/network/protocol/http/client/connection/ssl_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.hpp
@@ -29,7 +29,7 @@ struct ssl_delegate : connection_delegate,
                optional<std::string> private_key_file,
                optional<std::string> ciphers, long ssl_options);
 
-  virtual void connect(asio::ip::tcp::endpoint &endpoint, std::string host,
+  virtual void connect(asio::ip::tcp::endpoint &endpoint, std::string host, boost::uint16_t source_port,
                        function<void(system::error_code const &)> handler);
   virtual void write(
       asio::streambuf &command_streambuf,
@@ -49,7 +49,8 @@ struct ssl_delegate : connection_delegate,
   optional<std::string> ciphers_;
   long ssl_options_;
   scoped_ptr<asio::ssl::context> context_;
-  scoped_ptr<asio::ssl::stream<asio::ip::tcp::socket> > socket_;
+  scoped_ptr<asio::ip::tcp::socket> tcp_socket_;
+  scoped_ptr<asio::ssl::stream<asio::ip::tcp::socket&> > socket_;
   bool always_verify_peer_;
 
   ssl_delegate(ssl_delegate const &);     // = delete

--- a/boost/network/protocol/http/impl/request.hpp
+++ b/boost/network/protocol/http/impl/request.hpp
@@ -55,6 +55,7 @@ template <class Tag>
 struct basic_request : public basic_message<Tag> {
 
   mutable boost::network::uri::uri uri_;
+  unsigned short source_port_;
   typedef basic_message<Tag> base_type;
 
  public:
@@ -62,18 +63,18 @@ struct basic_request : public basic_message<Tag> {
   typedef typename string<tag>::type string_type;
   typedef boost::uint16_t port_type;
 
-  explicit basic_request(string_type const& uri_) : uri_(uri_) {}
+  explicit basic_request(string_type const& uri_) : uri_(uri_), source_port_(0) {}
 
-  explicit basic_request(boost::network::uri::uri const& uri_) : uri_(uri_) {}
+  explicit basic_request(boost::network::uri::uri const& uri_) : uri_(uri_), source_port_(0) {}
 
   void uri(string_type const& new_uri) { uri_ = new_uri; }
 
   void uri(boost::network::uri::uri const& new_uri) { uri_ = new_uri; }
 
-  basic_request() : base_type() {}
+  basic_request() : base_type(), source_port_(0) {}
 
   basic_request(basic_request const& other)
-      : base_type(other), uri_(other.uri_) {}
+      : base_type(other), uri_(other.uri_), source_port_(other.source_port_) {}
 
   basic_request& operator=(basic_request rhs) {
     rhs.swap(*this);
@@ -85,6 +86,7 @@ struct basic_request : public basic_message<Tag> {
     basic_request<Tag>& this_ref(*this);
     base_ref.swap(this_ref);
     boost::swap(other.uri_, this->uri_);
+    boost::swap(other.source_port_, this->source_port_);
   }
 
   string_type const host() const { return uri_.host(); }
@@ -110,6 +112,10 @@ struct basic_request : public basic_message<Tag> {
   void uri(string_type const& new_uri) const { uri_ = new_uri; }
 
   boost::network::uri::uri const& uri() const { return uri_; }
+
+  void setSourcePort(const unsigned short port) { source_port_ = port; }
+
+  unsigned short getSourcePort() const { return source_port_; }
 };
 
 /** This is the implementation of a POD request type

--- a/boost/network/protocol/http/impl/request.hpp
+++ b/boost/network/protocol/http/impl/request.hpp
@@ -55,7 +55,7 @@ template <class Tag>
 struct basic_request : public basic_message<Tag> {
 
   mutable boost::network::uri::uri uri_;
-  unsigned short source_port_;
+  boost::uint16_t source_port_;
   typedef basic_message<Tag> base_type;
 
  public:
@@ -113,9 +113,9 @@ struct basic_request : public basic_message<Tag> {
 
   boost::network::uri::uri const& uri() const { return uri_; }
 
-  void source_port(const unsigned short port) { source_port_ = port; }
+  void source_port(const boost::uint16_t port) { source_port_ = port; }
 
-  unsigned short source_port() const { return source_port_; }
+  boost::uint16_t source_port() const { return source_port_; }
 };
 
 /** This is the implementation of a POD request type

--- a/boost/network/protocol/http/impl/request.hpp
+++ b/boost/network/protocol/http/impl/request.hpp
@@ -113,9 +113,9 @@ struct basic_request : public basic_message<Tag> {
 
   boost::network::uri::uri const& uri() const { return uri_; }
 
-  void setSourcePort(const unsigned short port) { source_port_ = port; }
+  void source_port(const unsigned short port) { source_port_ = port; }
 
-  unsigned short getSourcePort() const { return source_port_; }
+  unsigned short source_port() const { return source_port_; }
 };
 
 /** This is the implementation of a POD request type


### PR DESCRIPTION
With this change it is possible to set the TCP source port of HTTP and HTTPS client requests by calling setSourcePort method of client::request object.