### PR TITLE
fix boost::network::uri::decode error - out of range because of '%'

### DIFF
--- a/boost/network/uri/decode.hpp
+++ b/boost/network/uri/decode.hpp
@@ -59,15 +59,9 @@ OutputIterator decode(const InputIterator &in_begin,
   OutputIterator out = out_begin;
   while (it != in_end) {
     if (*it == '%') {
-      ++it;
-	  if (it == in_end) {
-		throw std::runtime_error("decoding fail because of '%'");
-	  }
+	  if (++it == in_end) throw std::runtime_error("decoding fail because of '%'");
       value_type v0 = detail::letter_to_hex(*it);
-      ++it;
-	  if (it == in_end) {
-		throw std::runtime_error("decoding fail because of '%'");
-	  }
+	  if (++it == in_end) throw std::runtime_error("decoding fail because of '%'");
       value_type v1 = detail::letter_to_hex(*it);
       ++it;
       *out++ = 0x10 * v0 + v1;

--- a/boost/network/uri/decode.hpp
+++ b/boost/network/uri/decode.hpp
@@ -10,6 +10,7 @@
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <cassert>
+#include <stdexcept>
 
 namespace boost {
 namespace network {

--- a/boost/network/uri/decode.hpp
+++ b/boost/network/uri/decode.hpp
@@ -59,9 +59,9 @@ OutputIterator decode(const InputIterator &in_begin,
   OutputIterator out = out_begin;
   while (it != in_end) {
     if (*it == '%') {
-	  if (++it == in_end) throw std::out_of_range("out_of_range exception");
+	  if (++it == in_end) throw std::out_of_range("unexpected end of stream");
       value_type v0 = detail::letter_to_hex(*it);
-	  if (++it == in_end) throw std::out_of_range("out_of_range exception");
+	  if (++it == in_end) throw std::out_of_range("unexpected end of stream");
       value_type v1 = detail::letter_to_hex(*it);
       ++it;
       *out++ = 0x10 * v0 + v1;

--- a/boost/network/uri/decode.hpp
+++ b/boost/network/uri/decode.hpp
@@ -59,9 +59,9 @@ OutputIterator decode(const InputIterator &in_begin,
   OutputIterator out = out_begin;
   while (it != in_end) {
     if (*it == '%') {
-	  if (++it == in_end) throw std::runtime_error("decoding fail because of '%'");
+	  if (++it == in_end) throw std::out_of_range("out_of_range exception");
       value_type v0 = detail::letter_to_hex(*it);
-	  if (++it == in_end) throw std::runtime_error("decoding fail because of '%'");
+	  if (++it == in_end) throw std::out_of_range("out_of_range exception");
       value_type v1 = detail::letter_to_hex(*it);
       ++it;
       *out++ = 0x10 * v0 + v1;

--- a/boost/network/uri/decode.hpp
+++ b/boost/network/uri/decode.hpp
@@ -59,8 +59,14 @@ OutputIterator decode(const InputIterator &in_begin,
   while (it != in_end) {
     if (*it == '%') {
       ++it;
+	  if (it == in_end) {
+		throw std::runtime_error("decoding fail because of '%'");
+	  }
       value_type v0 = detail::letter_to_hex(*it);
       ++it;
+	  if (it == in_end) {
+		throw std::runtime_error("decoding fail because of '%'");
+	  }
       value_type v1 = detail::letter_to_hex(*it);
       ++it;
       *out++ = 0x10 * v0 + v1;

--- a/libs/network/test/http/client_get_timeout_test.cpp
+++ b/libs/network/test/http/client_get_timeout_test.cpp
@@ -25,8 +25,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(http_get_test_timeout_1_0, client, client_types) {
 BOOST_AUTO_TEST_CASE_TEMPLATE(http_get_test_timeout_with_options, client,
                               client_types) {
   typename client::request request(
-      "http://cznic.dl.sourceforge.net/project/boost/boost/1.55.0/"
-      "boost_1_55_0.tar.bz2");
+      "http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-desktop-amd64.iso");
   typename client::response response;
   typename client::options options;
   client client_(options.timeout(1));

--- a/libs/network/test/http/client_get_timeout_test.cpp
+++ b/libs/network/test/http/client_get_timeout_test.cpp
@@ -25,7 +25,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(http_get_test_timeout_1_0, client, client_types) {
 BOOST_AUTO_TEST_CASE_TEMPLATE(http_get_test_timeout_with_options, client,
                               client_types) {
   typename client::request request(
-      "http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-desktop-amd64.iso");
+      "http://cznic.dl.sourceforge.net/project/boost/boost/1.55.0/"
+      "boost_1_55_0.tar.bz2");
   typename client::response response;
   typename client::options options;
   client client_(options.timeout(1));

--- a/libs/network/test/uri/uri_encoding_test.cpp
+++ b/libs/network/test/uri/uri_encoding_test.cpp
@@ -47,3 +47,10 @@ BOOST_AUTO_TEST_CASE(decoding_multibyte_test) {
   uri::decode(encoded, std::back_inserter(instance));
   BOOST_CHECK_EQUAL(instance, unencoded);
 }
+
+BOOST_AUTO_TEST_CASE(decoding_throw_test) {
+  const std::string encoded("%");
+
+  std::string instance;
+  BOOST_CHECK_THROW(uri::decoded(encoded), std::runtime_error);
+}

--- a/libs/network/test/uri/uri_encoding_test.cpp
+++ b/libs/network/test/uri/uri_encoding_test.cpp
@@ -52,5 +52,5 @@ BOOST_AUTO_TEST_CASE(decoding_throw_test) {
   const std::string encoded("%");
 
   std::string instance;
-  BOOST_CHECK_THROW(uri::decoded(encoded), std::runtime_error);
+  BOOST_CHECK_THROW(uri::decoded(encoded), std::out_of_range);
 }


### PR DESCRIPTION
## problem
* if template type is "const char *" in boost::network::uri::detail::decode function,
segmentation fault can occor.

## cause
* "const char *" type is not throw std::out_of_range

## fix
* check out of range