### PR TITLE
Include missing boost/system/error_code.hpp

### DIFF
--- a/http/src/network/protocol/http/client/base.hpp
+++ b/http/src/network/protocol/http/client/base.hpp
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <boost/range/iterator_range.hpp>
+#include <boost/system/error_code.hpp>
 
 namespace network {
 namespace http {


### PR DESCRIPTION
Necessary to prevent the following error:

```c++
./network/protocol/http/client/base.hpp:27:19: error: 'system' is not a class, namespace, or enumeration
           boost::system::error_code const&)> body_callback_function_type;
```