### PR TITLE
Fixes http::async_connection::default_error that always set error flag 

### DIFF
--- a/boost/network/protocol/http/server/async_connection.hpp
+++ b/boost/network/protocol/http/server/async_connection.hpp
@@ -334,7 +334,7 @@ struct async_connection
   }
 
   void default_error(boost::system::error_code const& ec) {
-    error_encountered = in_place<boost::system::system_error>(ec);
+    if (ec) error_encountered = in_place<boost::system::system_error>(ec);
   }
 
   typedef boost::array<char, BOOST_NETWORK_HTTP_SERVER_CONNECTION_BUFFER_SIZE>


### PR DESCRIPTION
Fixes #271 

http::async_conection::write(Range) pass default_error function as callback for asynchronous operation. However, this function doesn't check error_code to 0 (aka success), so async_connection::has_error() is always set after async_connection::write(Range) completition. This causes next async_connection::write(...) calls to throw even if no errors.

I am also suggest to drop boost::optional wrapper of async_connection::error_encountered variable, because boost::system::system_error already have an "empty state" - errc::success.