### PR TITLE
Fix for issue #536 "hello_world_client can't commuicate with the hell…

### DIFF
--- a/boost/network/protocol/http/server/async_connection.hpp
+++ b/boost/network/protocol/http/server/async_connection.hpp
@@ -635,6 +635,14 @@ struct async_connection
       write_vec_impl(seq, callback, temporaries, buffers);
     };
     if (!headers_already_sent && !headers_in_progress) {
+      typedef constants<Tag> consts;
+      {
+        std::ostream stream(&headers_buffer);
+        stream << consts::http_slash() << 1 << consts::dot() << 1
+               << consts::space() << status << consts::space()
+               << status_message(status) << consts::crlf();
+        stream << consts::crlf();
+      }
       write_headers_only(continuation);
       return;
     }


### PR DESCRIPTION
The async server has to set headers in the handler, otherwise the client will throw " Invalid Version Part". Add HTTP version/status field even if don‘t call set_headers.