### PR TITLE
Fixed libraries to link, so ld will not fail on Linux with missing DSO

### DIFF
--- a/libs/network/test/http/CMakeLists.txt
+++ b/libs/network/test/http/CMakeLists.txt
@@ -84,7 +84,7 @@ if (Boost_FOUND)
     add_dependencies(cpp-netlib-http-server_async_run_stop_concurrency
       cppnetlib-server-parsers)
     target_link_libraries(cpp-netlib-http-server_async_run_stop_concurrency
-      ${Boost_LIBRARIES} cppnetlib-server-parsers)
+      ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} cppnetlib-server-parsers)
     if (OPENSSL_FOUND)
       target_link_libraries(cpp-netlib-http-server_async_run_stop_concurrency
 	${OPENSSL_LIBRARIES})


### PR DESCRIPTION
At least on openSUSE building of cpp-netlib (tests) fails with:
```missing DSO on commandline.```

This happens due to missing pthread on target_link_libraries for cpp-netlib-http-server_async_run_stop_concurrency test.