### PR TITLE
Several fixes to address OS X breakage in master

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -34,6 +34,9 @@ flags = [
     '-I', 'deps/googletest/googletest/include',
     '-I', 'deps/googletest/googlemock/include',
 
+    # add dependency to asio
+    '-I', 'deps/asio/asio/include',
+
     # Always enable debugging for the project when building for semantic
     # completion.
     '-DBOOST_NETWORK_DEBUG',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     # Use libc++ only in OS X.
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++")
   endif()
 endif()
 

--- a/boost/network/protocol/http/client/connection/async_base.hpp
+++ b/boost/network/protocol/http/client/connection/async_base.hpp
@@ -50,14 +50,13 @@ struct async_connection_base {
     typedef http_async_connection<Tag, version_major, version_minor>
         async_connection;
     typedef typename delegate_factory<Tag>::type delegate_factory_type;
-    connection_ptr temp;
-    temp.reset(new async_connection(
-        resolver, resolve, follow_redirect, timeout,
-        delegate_factory_type::new_connection_delegate(
-            resolver.get_io_service(), https, always_verify_peer,
-            certificate_filename, verify_path, certificate_file,
-            private_key_file, ciphers, ssl_options)));
-    BOOST_ASSERT(temp.get() != 0);
+    auto delegate = delegate_factory_type::new_connection_delegate(
+        resolver.get_io_service(), https, always_verify_peer,
+        certificate_filename, verify_path, certificate_file, private_key_file,
+        ciphers, ssl_options);
+    auto temp = std::make_shared<async_connection>(
+        resolver, resolve, follow_redirect, timeout, std::move(delegate));
+    BOOST_ASSERT(temp != nullptr);
     return temp;
   }
 

--- a/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
+++ b/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
@@ -31,8 +31,7 @@ struct connection_delegate_factory {
   typedef std::shared_ptr<connection_delegate> connection_delegate_ptr;
   typedef typename string<Tag>::type string_type;
 
-  // This is the factory method that actually returns the delegate
-  // instance.
+  // This is the factory method that actually returns the delegate instance.
   // TODO(dberris): Support passing in proxy settings when crafting connections.
   static connection_delegate_ptr new_connection_delegate(
       asio::io_service& service, bool https, bool always_verify_peer,
@@ -43,27 +42,23 @@ struct connection_delegate_factory {
     connection_delegate_ptr delegate;
     if (https) {
 #ifdef BOOST_NETWORK_ENABLE_HTTPS
-      delegate.reset(new ssl_delegate(
+      delegate = std::make_shared<ssl_delegate>(
           service, always_verify_peer, certificate_filename, verify_path,
-          certificate_file, private_key_file, ciphers, ssl_options));
+          certificate_file, private_key_file, ciphers, ssl_options);
 #else
       BOOST_THROW_EXCEPTION(std::runtime_error("HTTPS not supported."));
 #endif /* BOOST_NETWORK_ENABLE_HTTPS */
     } else {
-      delegate.reset(new normal_delegate(service));
+      delegate = std::make_shared<normal_delegate>(service);
     }
     return delegate;
   }
 };
 
 }  // namespace impl
- /* impl */
-} // namespace http
- /* http */
-} // namespace network
- /* network */
-} // namespace boost
- /* boost */
+}  // namespace http
+}  // namespace network
+}  // namespace boost
 
 #endif /* BOOST_NETWORK_PROTOCOL_HTTP_CLIENT_CONNECTION_DELEGATE_FACTORY_HPP_20110819 \
           */

--- a/boost/network/protocol/http/client/connection/ssl_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.hpp
@@ -22,8 +22,8 @@ namespace network {
 namespace http {
 namespace impl {
 
-struct ssl_delegate : connection_delegate,
-                      std::enable_shared_from_this<ssl_delegate> {
+struct ssl_delegate : public connection_delegate,
+                      public std::enable_shared_from_this<ssl_delegate> {
   ssl_delegate(asio::io_service &service, bool always_verify_peer,
                optional<std::string> certificate_filename,
                optional<std::string> verify_path,
@@ -32,14 +32,14 @@ struct ssl_delegate : connection_delegate,
                optional<std::string> ciphers, long ssl_options);
 
   void connect(asio::ip::tcp::endpoint &endpoint, std::string host,
-                       std::uint16_t source_port,
-                       std::function<void(std::error_code const &)> handler) override;
-  void write(asio::streambuf &command_streambuf,
-             std::function<void(std::error_code const &, size_t)> handler)
-      override;
-  void read_some(asio::mutable_buffers_1 const &read_buffer,
-                 std::function<void(std::error_code const &, size_t)> handler)
-      override;
+               std::uint16_t source_port,
+               std::function<void(std::error_code const &)> handler) override;
+  void write(
+      asio::streambuf &command_streambuf,
+      std::function<void(std::error_code const &, size_t)> handler) override;
+  void read_some(
+      asio::mutable_buffers_1 const &read_buffer,
+      std::function<void(std::error_code const &, size_t)> handler) override;
   void disconnect() override;
   ~ssl_delegate() override;
 
@@ -68,9 +68,4 @@ struct ssl_delegate : connection_delegate,
 }  // namespace network
 }  // namespace boost
 
-#ifdef BOOST_NETWORK_NO_LIB
-#include <boost/network/protocol/http/client/connection/ssl_delegate.ipp>
-#endif /* BOOST_NETWORK_NO_LIB */
-
-#endif /* BOOST_NETWORK_PROTOCOL_HTTP_CLIENT_CONNECTION_SSL_DELEGATE_20110819 \
-          */
+#endif  // BOOST_NETWORK_PROTOCOL_HTTP_CLIENT_CONNECTION_SSL_DELEGATE_20110819

--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -44,9 +44,6 @@ set_target_properties(cppnetlib-client-connections
 if (OPENSSL_FOUND)
     target_link_libraries(cppnetlib-client-connections ${OPENSSL_LIBRARIES})
 endif ()
-if (Boost_FOUND)
-    target_link_libraries(cppnetlib-client-connections)
-endif ()
 install(TARGETS cppnetlib-client-connections
     EXPORT cppnetlibTargets
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}


### PR DESCRIPTION
The changes centre around how we're using std::shared_ptr<...> which has a stricter implementation in libc++ than in libstdc++ or Boost. Essentially, instead of doing:

shared_ptr.reset(new derived_type(...));

We do:

shared_ptr = std::make_shared<derived_type>(...);