### PR TITLE
[#600] Add TLS SNI hostname to client options

### DIFF
--- a/boost/network/protocol/http/client/async_impl.hpp
+++ b/boost/network/protocol/http/client/async_impl.hpp
@@ -44,7 +44,8 @@ struct async_client
                optional<string_type> verify_path,
                optional<string_type> certificate_file,
                optional<string_type> private_key_file,
-               optional<string_type> ciphers, long ssl_options)
+               optional<string_type> ciphers,
+               optional<string_type> sni_hostname, long ssl_options)
       : connection_base(cache_resolved, follow_redirect, timeout),
         service_ptr(service.get()
                         ? service
@@ -57,6 +58,7 @@ struct async_client
         certificate_file_(std::move(certificate_file)),
         private_key_file_(std::move(private_key_file)),
         ciphers_(std::move(ciphers)),
+        sni_hostname_(std::move(sni_hostname)),
         ssl_options_(ssl_options),
         always_verify_peer_(always_verify_peer) {
     connection_base::resolver_strand_.reset(
@@ -84,7 +86,7 @@ struct async_client
     connection_ = connection_base::get_connection(
         resolver_, request_, always_verify_peer_, certificate_filename_,
         verify_path_, certificate_file_, private_key_file_, ciphers_,
-        ssl_options_);
+        sni_hostname_, ssl_options_);
     return connection_->send_request(method, request_, get_body, callback,
                                      generator);
   }
@@ -99,6 +101,7 @@ struct async_client
   optional<string_type> certificate_file_;
   optional<string_type> private_key_file_;
   optional<string_type> ciphers_;
+  optional<string_type> sni_hostname_;
   long ssl_options_;
   bool always_verify_peer_;
 };

--- a/boost/network/protocol/http/client/connection/async_base.hpp
+++ b/boost/network/protocol/http/client/connection/async_base.hpp
@@ -45,6 +45,7 @@ struct async_connection_base {
       optional<string_type> certificate_file = optional<string_type>(),
       optional<string_type> private_key_file = optional<string_type>(),
       optional<string_type> ciphers = optional<string_type>(),
+      optional<string_type> sni_hostname = optional<string_type>(),
       long ssl_options = 0) {
     typedef http_async_connection<Tag, version_major, version_minor>
         async_connection;
@@ -55,7 +56,7 @@ struct async_connection_base {
         delegate_factory_type::new_connection_delegate(
             resolver.get_io_service(), https, always_verify_peer,
             certificate_filename, verify_path, certificate_file,
-            private_key_file, ciphers, ssl_options)));
+            private_key_file, ciphers, sni_hostname, ssl_options)));
     BOOST_ASSERT(temp.get() != 0);
     return temp;
   }

--- a/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
+++ b/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
@@ -39,13 +39,14 @@ struct connection_delegate_factory {
       optional<string_type> certificate_filename,
       optional<string_type> verify_path, optional<string_type> certificate_file,
       optional<string_type> private_key_file, optional<string_type> ciphers,
-      long ssl_options) {
+      optional<string_type> sni_hostname, long ssl_options) {
     connection_delegate_ptr delegate;
     if (https) {
 #ifdef BOOST_NETWORK_ENABLE_HTTPS
-      delegate.reset(new ssl_delegate(
-          service, always_verify_peer, certificate_filename, verify_path,
-          certificate_file, private_key_file, ciphers, ssl_options));
+      delegate.reset(new ssl_delegate(service, always_verify_peer,
+                                      certificate_filename, verify_path,
+                                      certificate_file, private_key_file,
+                                      ciphers, sni_hostname, ssl_options));
 #else
       BOOST_THROW_EXCEPTION(std::runtime_error("HTTPS not supported."));
 #endif /* BOOST_NETWORK_ENABLE_HTTPS */
@@ -57,13 +58,13 @@ struct connection_delegate_factory {
 };
 
 }  // namespace impl
- /* impl */
-} // namespace http
- /* http */
-} // namespace network
- /* network */
-} // namespace boost
- /* boost */
+   /* impl */
+}  // namespace http
+   /* http */
+}  // namespace network
+   /* network */
+}  // namespace boost
+   /* boost */
 
 #endif /* BOOST_NETWORK_PROTOCOL_HTTP_CLIENT_CONNECTION_DELEGATE_FACTORY_HPP_20110819 \
           */

--- a/boost/network/protocol/http/client/connection/ssl_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.hpp
@@ -28,17 +28,18 @@ struct ssl_delegate : connection_delegate,
                optional<std::string> verify_path,
                optional<std::string> certificate_file,
                optional<std::string> private_key_file,
-               optional<std::string> ciphers, long ssl_options);
+               optional<std::string> ciphers,
+               optional<std::string> sni_hostname, long ssl_options);
 
   void connect(asio::ip::tcp::endpoint &endpoint, std::string host,
-                       boost::uint16_t source_port,
-                       function<void(system::error_code const &)> handler) override;
-  void write(asio::streambuf &command_streambuf,
-             function<void(system::error_code const &, size_t)> handler)
-      override;
-  void read_some(asio::mutable_buffers_1 const &read_buffer,
-                 function<void(system::error_code const &, size_t)> handler)
-      override;
+               boost::uint16_t source_port,
+               function<void(system::error_code const &)> handler) override;
+  void write(
+      asio::streambuf &command_streambuf,
+      function<void(system::error_code const &, size_t)> handler) override;
+  void read_some(
+      asio::mutable_buffers_1 const &read_buffer,
+      function<void(system::error_code const &, size_t)> handler) override;
   void disconnect() override;
   ~ssl_delegate() override;
 
@@ -49,6 +50,7 @@ struct ssl_delegate : connection_delegate,
   optional<std::string> certificate_file_;
   optional<std::string> private_key_file_;
   optional<std::string> ciphers_;
+  optional<std::string> sni_hostname_;
   long ssl_options_;
   std::unique_ptr<asio::ssl::context> context_;
   std::unique_ptr<asio::ip::tcp::socket> tcp_socket_;

--- a/boost/network/protocol/http/client/facade.hpp
+++ b/boost/network/protocol/http/client/facade.hpp
@@ -25,7 +25,6 @@ struct basic_response;
 
 template <class Tag, unsigned version_major, unsigned version_minor>
 struct basic_client_facade {
-
   typedef typename string<Tag>::type string_type;
   typedef basic_request<Tag> request;
   typedef basic_response<Tag> response;
@@ -53,12 +52,12 @@ struct basic_client_facade {
                                    body_generator_function_type());
   }
 
-  response post(request request, string_type const& body = string_type(),
-                string_type const& content_type = string_type(),
-                body_callback_function_type body_handler =
-                    body_callback_function_type(),
-                body_generator_function_type body_generator =
-                    body_generator_function_type()) {
+  response post(
+      request request, string_type const& body = string_type(),
+      string_type const& content_type = string_type(),
+      body_callback_function_type body_handler = body_callback_function_type(),
+      body_generator_function_type body_generator =
+          body_generator_function_type()) {
     if (body != string_type()) {
       request << remove_header("Content-Length")
               << header("Content-Length",
@@ -82,10 +81,9 @@ struct basic_client_facade {
                                    body_generator);
   }
 
-  response post(request const& request,
-                body_generator_function_type body_generator,
-                body_callback_function_type callback =
-                    body_generator_function_type()) {
+  response post(
+      request const& request, body_generator_function_type body_generator,
+      body_callback_function_type callback = body_generator_function_type()) {
     return pimpl->request_skeleton(request, "POST", true, callback,
                                    body_generator);
   }
@@ -104,12 +102,12 @@ struct basic_client_facade {
     return post(request, body, string_type(), callback, body_generator);
   }
 
-  response put(request request, string_type const& body = string_type(),
-               string_type const& content_type = string_type(),
-               body_callback_function_type body_handler =
-                   body_callback_function_type(),
-               body_generator_function_type body_generator =
-                   body_generator_function_type()) {
+  response put(
+      request request, string_type const& body = string_type(),
+      string_type const& content_type = string_type(),
+      body_callback_function_type body_handler = body_callback_function_type(),
+      body_generator_function_type body_generator =
+          body_generator_function_type()) {
     if (body != string_type()) {
       request << remove_header("Content-Length")
               << header("Content-Length",
@@ -164,7 +162,8 @@ struct basic_client_facade {
         options.always_verify_peer(), options.openssl_certificate(),
         options.openssl_verify_path(), options.openssl_certificate_file(),
         options.openssl_private_key_file(), options.openssl_ciphers(),
-        options.openssl_options(), options.io_service(), options.timeout()));
+        options.openssl_sni_hostname(), options.openssl_options(),
+        options.io_service(), options.timeout()));
   }
 };
 

--- a/boost/network/protocol/http/client/options.hpp
+++ b/boost/network/protocol/http/client/options.hpp
@@ -28,6 +28,7 @@ struct client_options {
         openssl_certificate_file_(),
         openssl_private_key_file_(),
         openssl_ciphers_(),
+        openssl_sni_hostname_(),
         openssl_options_(0),
         io_service_(),
         always_verify_peer_(false),
@@ -41,6 +42,7 @@ struct client_options {
         openssl_certificate_file_(other.openssl_certificate_file_),
         openssl_private_key_file_(other.openssl_private_key_file_),
         openssl_ciphers_(other.openssl_ciphers_),
+        openssl_sni_hostname_(other.openssl_sni_hostname_),
         openssl_options_(other.openssl_options_),
         io_service_(other.io_service_),
         always_verify_peer_(other.always_verify_peer_),
@@ -60,6 +62,7 @@ struct client_options {
     swap(openssl_certificate_file_, other.openssl_certificate_file_);
     swap(openssl_private_key_file_, other.openssl_private_key_file_);
     swap(openssl_ciphers_, other.openssl_ciphers_);
+    swap(openssl_sni_hostname_, other.openssl_sni_hostname_);
     swap(openssl_options_, other.openssl_options_);
     swap(io_service_, other.io_service_);
     swap(always_verify_peer_, other.always_verify_peer_);
@@ -98,6 +101,11 @@ struct client_options {
 
   client_options& openssl_ciphers(string_type const& v) {
     openssl_ciphers_ = v;
+    return *this;
+  }
+
+  client_options& openssl_sni_hostname(string_type const& v) {
+    openssl_sni_hostname_ = v;
     return *this;
   }
 
@@ -145,6 +153,10 @@ struct client_options {
     return openssl_ciphers_;
   }
 
+  boost::optional<string_type> openssl_sni_hostname() const {
+    return openssl_sni_hostname_;
+  }
+
   long openssl_options() const { return openssl_options_; }
 
   boost::shared_ptr<boost::asio::io_service> io_service() const {
@@ -163,6 +175,7 @@ struct client_options {
   boost::optional<string_type> openssl_certificate_file_;
   boost::optional<string_type> openssl_private_key_file_;
   boost::optional<string_type> openssl_ciphers_;
+  boost::optional<string_type> openssl_sni_hostname_;
   long openssl_options_;
   boost::shared_ptr<boost::asio::io_service> io_service_;
   bool always_verify_peer_;

--- a/boost/network/protocol/http/client/pimpl.hpp
+++ b/boost/network/protocol/http/client/pimpl.hpp
@@ -73,12 +73,13 @@ struct basic_client_impl
                     optional<string_type> const& verify_path,
                     optional<string_type> const& certificate_file,
                     optional<string_type> const& private_key_file,
-                    optional<string_type> const& ciphers, long ssl_options,
+                    optional<string_type> const& ciphers,
+                    optional<string_type> const& sni_hostname, long ssl_options,
                     boost::shared_ptr<boost::asio::io_service> service,
                     int timeout)
       : base_type(cache_resolved, follow_redirect, always_verify_peer, timeout,
                   service, certificate_filename, verify_path, certificate_file,
-                  private_key_file, ciphers, ssl_options) {}
+                  private_key_file, ciphers, sni_hostname, ssl_options) {}
 
   ~basic_client_impl() = default;
 };

--- a/boost/network/protocol/http/client/sync_impl.hpp
+++ b/boost/network/protocol/http/client/sync_impl.hpp
@@ -46,18 +46,19 @@ struct sync_client
   optional<string_type> certificate_file_;
   optional<string_type> private_key_file_;
   optional<string_type> ciphers_;
+  optional<string_type> sni_hostname_;
   long ssl_options_;
   bool always_verify_peer_;
 
   sync_client(
       bool cache_resolved, bool follow_redirect, bool always_verify_peer,
       int timeout, boost::shared_ptr<boost::asio::io_service> service,
-      optional<string_type>  certificate_filename =
-          optional<string_type>(),
-      optional<string_type>  verify_path = optional<string_type>(),
-      optional<string_type>  certificate_file = optional<string_type>(),
-      optional<string_type>  private_key_file = optional<string_type>(),
-      optional<string_type>  ciphers = optional<string_type>(),
+      optional<string_type> certificate_filename = optional<string_type>(),
+      optional<string_type> verify_path = optional<string_type>(),
+      optional<string_type> certificate_file = optional<string_type>(),
+      optional<string_type> private_key_file = optional<string_type>(),
+      optional<string_type> ciphers = optional<string_type>(),
+      optional<string_type> sni_hostname = optional<string_type>(),
       long ssl_options = 0)
       : connection_base(cache_resolved, follow_redirect, timeout),
         service_ptr(service.get() ? service
@@ -69,6 +70,7 @@ struct sync_client
         certificate_file_(std::move(certificate_file)),
         private_key_file_(std::move(private_key_file)),
         ciphers_(std::move(ciphers)),
+        sni_hostname_(std::move(sni_hostname)),
         ssl_options_(ssl_options),
         always_verify_peer_(always_verify_peer) {}
 
@@ -83,7 +85,8 @@ struct sync_client
     typename connection_base::connection_ptr connection_;
     connection_ = connection_base::get_connection(
         resolver_, request_, always_verify_peer_, certificate_filename_,
-        verify_path_, certificate_file_, private_key_file_, ciphers_);
+        verify_path_, certificate_file_, private_key_file_, ciphers_,
+        sni_hostname_);
     return connection_->send_request(method, request_, get_body, callback,
                                      generator);
   }

--- a/boost/network/protocol/http/policies/async_connection.hpp
+++ b/boost/network/protocol/http/policies/async_connection.hpp
@@ -37,24 +37,25 @@ struct async_connection_policy : resolver_policy<Tag>::type {
   typedef function<bool(string_type&)> body_generator_function_type;
 
   struct connection_impl {
-    connection_impl(bool follow_redirect, bool always_verify_peer,
-                    resolve_function resolve, resolver_type& resolver,
-                    bool https, int timeout,
-                    optional<string_type>  /*unused*/const& certificate_filename,
-                    optional<string_type> const& verify_path,
-                    optional<string_type> const& certificate_file,
-                    optional<string_type> const& private_key_file,
-                    optional<string_type> const& ciphers, long ssl_options) {
+    connection_impl(
+        bool follow_redirect, bool always_verify_peer, resolve_function resolve,
+        resolver_type& resolver, bool https, int timeout,
+        optional<string_type> /*unused*/ const& certificate_filename,
+        optional<string_type> const& verify_path,
+        optional<string_type> const& certificate_file,
+        optional<string_type> const& private_key_file,
+        optional<string_type> const& ciphers,
+        optional<string_type> const& sni_hostname, long ssl_options) {
       pimpl = impl::async_connection_base<
           Tag, version_major,
           version_minor>::new_connection(resolve, resolver, follow_redirect,
                                          always_verify_peer, https, timeout,
                                          certificate_filename, verify_path,
                                          certificate_file, private_key_file,
-                                         ciphers, ssl_options);
+                                         ciphers, sni_hostname, ssl_options);
     }
 
-    basic_response<Tag> send_request(string_type  /*unused*/const& method,
+    basic_response<Tag> send_request(string_type /*unused*/ const& method,
                                      basic_request<Tag> const& request_,
                                      bool get_body,
                                      body_callback_function_type callback,
@@ -71,12 +72,13 @@ struct async_connection_policy : resolver_policy<Tag>::type {
   connection_ptr get_connection(
       resolver_type& resolver, basic_request<Tag> const& request_,
       bool always_verify_peer,
-      optional<string_type>  /*unused*/const& certificate_filename =
+      optional<string_type> /*unused*/ const& certificate_filename =
           optional<string_type>(),
       optional<string_type> const& verify_path = optional<string_type>(),
       optional<string_type> const& certificate_file = optional<string_type>(),
       optional<string_type> const& private_key_file = optional<string_type>(),
       optional<string_type> const& ciphers = optional<string_type>(),
+      optional<string_type> const& sni_hostname = optional<string_type>(),
       long ssl_options = 0) {
     string_type protocol_ = protocol(request_);
     connection_ptr connection_(new connection_impl(
@@ -87,7 +89,7 @@ struct async_connection_policy : resolver_policy<Tag>::type {
                     boost::arg<4>()),
         resolver, boost::iequals(protocol_, string_type("https")), timeout_,
         certificate_filename, verify_path, certificate_file, private_key_file,
-        ciphers, ssl_options));
+        ciphers, sni_hostname, ssl_options));
     return connection_;
   }
 


### PR DESCRIPTION
This PR adds a new member and API to `http::client::options` for an optional TLS SNI hostname. HTTPS client option callsites may optionally support/provide an SNI hostname:

```cpp
http::client::options options;
options.openssl_sni_hostname("my.shared.host");

http::client client(options);
```

The implementation within `ssl_delegate` and `sync_ssl` arrive at an OpenSSL (and equivalent API implementations): `SSL_set_tlsext_host_name`. See the OpenSSL wiki for [TLS SNI details](https://wiki.openssl.org/index.php/SSL/TLS_Client), as well as usage examples.

Also, there are various non-thesis related style changes pulled in via `clang-format` and the project's local format file. Please let me know if it is unacceptable to piggy-back these changes and I will try to remove them. Most of my editors auto-format so pulling out the changes is *doable*. :scream_cat: :wink: 