### PR TITLE
[#600] Add TLS SNI hostname to client options

### DIFF
--- a/boost/network/protocol/http/client/async_impl.hpp
+++ b/boost/network/protocol/http/client/async_impl.hpp
@@ -32,7 +32,8 @@ struct async_client
   typedef typename string<Tag>::type string_type;
 
   typedef std::function<void(boost::iterator_range<char const*> const&,
-                        std::error_code const&)> body_callback_function_type;
+                             std::error_code const&)>
+      body_callback_function_type;
 
   typedef std::function<bool(string_type&)> body_generator_function_type;
 
@@ -43,11 +44,11 @@ struct async_client
                optional<string_type> verify_path,
                optional<string_type> certificate_file,
                optional<string_type> private_key_file,
-               optional<string_type> ciphers, long ssl_options)
+               optional<string_type> ciphers,
+               optional<string_type> sni_hostname, long ssl_options)
       : connection_base(cache_resolved, follow_redirect, timeout),
-        service_ptr(service.get()
-                        ? service
-                        : std::make_shared<asio::io_service>()),
+        service_ptr(service.get() ? service
+                                  : std::make_shared<asio::io_service>()),
         service_(*service_ptr),
         resolver_(service_),
         sentinel_(new asio::io_service::work(service_)),
@@ -56,12 +57,13 @@ struct async_client
         certificate_file_(std::move(certificate_file)),
         private_key_file_(std::move(private_key_file)),
         ciphers_(std::move(ciphers)),
+        sni_hostname_(std::move(sni_hostname)),
         ssl_options_(ssl_options),
         always_verify_peer_(always_verify_peer) {
     connection_base::resolver_strand_.reset(
         new asio::io_service::strand(service_));
     if (!service)
-      lifetime_thread_.reset(new std::thread([this] () { service_.run(); }));
+      lifetime_thread_.reset(new std::thread([this]() { service_.run(); }));
   }
 
   ~async_client() throw() = default;
@@ -82,7 +84,7 @@ struct async_client
     connection_ = connection_base::get_connection(
         resolver_, request_, always_verify_peer_, certificate_filename_,
         verify_path_, certificate_file_, private_key_file_, ciphers_,
-        ssl_options_);
+        sni_hostname_, ssl_options_);
     return connection_->send_request(method, request_, get_body, callback,
                                      generator);
   }
@@ -97,6 +99,7 @@ struct async_client
   optional<string_type> certificate_file_;
   optional<string_type> private_key_file_;
   optional<string_type> ciphers_;
+  optional<string_type> sni_hostname_;
   long ssl_options_;
   bool always_verify_peer_;
 };

--- a/boost/network/protocol/http/client/connection/async_base.hpp
+++ b/boost/network/protocol/http/client/connection/async_base.hpp
@@ -46,6 +46,7 @@ struct async_connection_base {
       optional<string_type> certificate_file = optional<string_type>(),
       optional<string_type> private_key_file = optional<string_type>(),
       optional<string_type> ciphers = optional<string_type>(),
+      optional<string_type> sni_hostname = optional<string_type>(),
       long ssl_options = 0) {
     typedef http_async_connection<Tag, version_major, version_minor>
         async_connection;
@@ -53,7 +54,7 @@ struct async_connection_base {
     auto delegate = delegate_factory_type::new_connection_delegate(
         resolver.get_io_service(), https, always_verify_peer,
         certificate_filename, verify_path, certificate_file, private_key_file,
-        ciphers, ssl_options);
+        ciphers, sni_hostname, ssl_options);
     auto temp = std::make_shared<async_connection>(
         resolver, resolve, follow_redirect, timeout, std::move(delegate));
     BOOST_ASSERT(temp != nullptr);

--- a/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
+++ b/boost/network/protocol/http/client/connection/connection_delegate_factory.hpp
@@ -38,13 +38,14 @@ struct connection_delegate_factory {
       optional<string_type> certificate_filename,
       optional<string_type> verify_path, optional<string_type> certificate_file,
       optional<string_type> private_key_file, optional<string_type> ciphers,
-      long ssl_options) {
+      optional<string_type> sni_hostname, long ssl_options) {
     connection_delegate_ptr delegate;
     if (https) {
 #ifdef BOOST_NETWORK_ENABLE_HTTPS
       delegate = std::make_shared<ssl_delegate>(
           service, always_verify_peer, certificate_filename, verify_path,
-          certificate_file, private_key_file, ciphers, ssl_options);
+          certificate_file, private_key_file, ciphers, sni_hostname,
+          ssl_options);
 #else
       BOOST_THROW_EXCEPTION(std::runtime_error("HTTPS not supported."));
 #endif /* BOOST_NETWORK_ENABLE_HTTPS */

--- a/boost/network/protocol/http/client/connection/ssl_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.hpp
@@ -29,7 +29,8 @@ struct ssl_delegate : public connection_delegate,
                optional<std::string> verify_path,
                optional<std::string> certificate_file,
                optional<std::string> private_key_file,
-               optional<std::string> ciphers, long ssl_options);
+               optional<std::string> ciphers,
+               optional<std::string> sni_hostname, long ssl_options);
 
   void connect(asio::ip::tcp::endpoint &endpoint, std::string host,
                std::uint16_t source_port,
@@ -50,6 +51,7 @@ struct ssl_delegate : public connection_delegate,
   optional<std::string> certificate_file_;
   optional<std::string> private_key_file_;
   optional<std::string> ciphers_;
+  optional<std::string> sni_hostname_;
   long ssl_options_;
   std::unique_ptr<asio::ssl::context> context_;
   std::unique_ptr<asio::ip::tcp::socket> tcp_socket_;

--- a/boost/network/protocol/http/client/connection/sync_base.hpp
+++ b/boost/network/protocol/http/client/connection/sync_base.hpp
@@ -39,8 +39,8 @@ struct sync_connection_base_impl {
 
   template <class Socket>
   void init_socket(Socket& socket_, resolver_type& resolver_,
-                   string_type  /*unused*/const& hostname, string_type const& port,
-                   resolver_function_type resolve_) {
+                   string_type /*unused*/ const& hostname,
+                   string_type const& port, resolver_function_type resolve_) {
     using asio::ip::tcp;
     std::error_code error = asio::error::host_not_found;
     typename resolver_type::iterator endpoint_iterator, end;
@@ -100,7 +100,7 @@ struct sync_connection_base_impl {
   }
 
   template <class Socket>
-  void send_request_impl(Socket& socket_, string_type  /*unused*/const& method,
+  void send_request_impl(Socket& socket_, string_type /*unused*/ const& method,
                          asio::streambuf& request_buffer) {
     // TODO(dberris): review parameter necessity.
     (void)method;
@@ -118,8 +118,8 @@ struct sync_connection_base_impl {
     std::error_code error;
     if (response_buffer.size() > 0) body_stream << &response_buffer;
 
-    while (asio::read(socket_, response_buffer,
-                             asio::transfer_at_least(1), error)) {
+    while (asio::read(socket_, response_buffer, asio::transfer_at_least(1),
+                      error)) {
       body_stream << &response_buffer;
     }
   }
@@ -171,8 +171,7 @@ struct sync_connection_base_impl {
                     read(socket_, response_buffer,
                          asio::transfer_at_least(bytes_to_read), error);
                 if (chunk_bytes_read == 0) {
-                  if (error != asio::error::eof)
-                    throw std::system_error(error);
+                  if (error != asio::error::eof) throw std::system_error(error);
                   stopping_inner = true;
                 }
               }
@@ -195,14 +194,14 @@ struct sync_connection_base_impl {
     } else {
       size_t already_read = response_buffer.size();
       if (already_read) body_stream << &response_buffer;
-      size_t length = std::stoul(std::begin(content_length_range)->second) -
-          already_read;
-      if (length == 0) { return;
-}
+      size_t length =
+          std::stoul(std::begin(content_length_range)->second) - already_read;
+      if (length == 0) {
+        return;
+      }
       size_t bytes_read = 0;
       while ((bytes_read = asio::read(socket_, response_buffer,
-                                             asio::transfer_at_least(1),
-                                             error))) {
+                                      asio::transfer_at_least(1), error))) {
         body_stream << &response_buffer;
         length -= bytes_read;
         if ((length <= 0) || error) break;
@@ -223,7 +222,7 @@ struct sync_connection_base_impl {
       } else {
         read_body_transfer_chunk_encoding(socket_, response_, response_buffer,
                                           body_stream);
-}
+      }
     } else {
       throw std::runtime_error("Unsupported HTTP version number.");
     }
@@ -249,7 +248,7 @@ struct sync_connection_base {
       new_connection(
           resolver_type& resolver, resolver_function_type resolve, bool https,
           bool always_verify_peer, int timeout,
-          optional<string_type>  /*unused*/const& certificate_filename =
+          optional<string_type> /*unused*/ const& certificate_filename =
               optional<string_type>(),
           optional<string_type> const& verify_path = optional<string_type>(),
           optional<string_type> const& certificate_file =
@@ -257,6 +256,7 @@ struct sync_connection_base {
           optional<string_type> const& private_key_file =
               optional<string_type>(),
           optional<string_type> const& ciphers = optional<string_type>(),
+          optional<string_type> const& sni_hostname = optional<string_type>(),
           long ssl_options = 0) {
     if (https) {
 #ifdef BOOST_NETWORK_ENABLE_HTTPS
@@ -265,7 +265,7 @@ struct sync_connection_base {
           new https_sync_connection<Tag, version_major, version_minor>(
               resolver, resolve, always_verify_peer, timeout,
               certificate_filename, verify_path, certificate_file,
-              private_key_file, ciphers, ssl_options));
+              private_key_file, ciphers, sni_hostname, ssl_options));
 #else
       throw std::runtime_error("HTTPS not supported.");
 #endif

--- a/boost/network/protocol/http/client/facade.hpp
+++ b/boost/network/protocol/http/client/facade.hpp
@@ -26,6 +26,7 @@ struct basic_response;
 template <class Tag, unsigned version_major, unsigned version_minor>
 class basic_client_facade {
   typedef basic_client_impl<Tag, version_major, version_minor> pimpl_type;
+
  public:
   /**
    * The type to use for strings associated with this client. Typically resolves
@@ -45,7 +46,8 @@ class basic_client_facade {
    * code.
    */
   typedef std::function<void(iterator_range<char const*> const&,
-                        std::error_code const&)> body_callback_function_type;
+                             std::error_code const&)>
+      body_callback_function_type;
 
   /**
    * Functions that model this signature will be used to generate part of the
@@ -106,16 +108,15 @@ class basic_client_facade {
    * @throws std::exception May throw exceptions on errors, derived from
    *   `std::exception`.
    */
-  response post(request request, string_type const& body = string_type(),
-                string_type const& content_type = string_type(),
-                body_callback_function_type body_handler =
-                    body_callback_function_type(),
-                body_generator_function_type body_generator =
-                    body_generator_function_type()) {
+  response post(
+      request request, string_type const& body = string_type(),
+      string_type const& content_type = string_type(),
+      body_callback_function_type body_handler = body_callback_function_type(),
+      body_generator_function_type body_generator =
+          body_generator_function_type()) {
     if (body != string_type()) {
       request << remove_header("Content-Length")
-              << header("Content-Length",
-                        std::to_string(body.size()))
+              << header("Content-Length", std::to_string(body.size()))
               << boost::network::body(body);
     }
     typename headers_range<basic_request<Tag> >::type content_type_headers =
@@ -152,7 +153,7 @@ class basic_client_facade {
                 body_callback_function_type body_handler =
                     body_callback_function_type()) {
     return pimpl->request_skeleton(request, "POST", true, body_handler,
-	body_generator);
+                                   body_generator);
   }
 
   /**
@@ -167,11 +168,12 @@ class basic_client_facade {
    * @throws std::exception May throw exceptions derived from std::exception in
    *   case of errors.
    */
-  response post(request const& request, body_callback_function_type body_handler,
+  response post(request const& request,
+                body_callback_function_type body_handler,
                 body_generator_function_type body_generator =
                     body_generator_function_type()) {
     return post(request, string_type(), string_type(), body_handler,
-	body_generator);
+                body_generator);
   }
 
   /**
@@ -211,16 +213,15 @@ class basic_client_facade {
    * @throws std::exception May throw exceptions on errors, derived from
    *   `std::exception`.
    */
-  response put(request request, string_type const& body = string_type(),
-               string_type const& content_type = string_type(),
-               body_callback_function_type body_handler =
-                   body_callback_function_type(),
-               body_generator_function_type body_generator =
-                   body_generator_function_type()) {
+  response put(
+      request request, string_type const& body = string_type(),
+      string_type const& content_type = string_type(),
+      body_callback_function_type body_handler = body_callback_function_type(),
+      body_generator_function_type body_generator =
+          body_generator_function_type()) {
     if (body != string_type()) {
       request << remove_header("Content-Length")
-              << header("Content-Length",
-                        std::to_string(body.size()))
+              << header("Content-Length", std::to_string(body.size()))
               << boost::network::body(body);
     }
     typename headers_range<basic_request<Tag> >::type content_type_headers =
@@ -307,7 +308,8 @@ class basic_client_facade {
         options.always_verify_peer(), options.openssl_certificate(),
         options.openssl_verify_path(), options.openssl_certificate_file(),
         options.openssl_private_key_file(), options.openssl_ciphers(),
-        options.openssl_options(), options.io_service(), options.timeout()));
+        options.openssl_sni_hostname(), options.openssl_options(),
+        options.io_service(), options.timeout()));
   }
 };
 

--- a/boost/network/protocol/http/client/options.hpp
+++ b/boost/network/protocol/http/client/options.hpp
@@ -29,6 +29,7 @@ class client_options {
         openssl_certificate_file_(),
         openssl_private_key_file_(),
         openssl_ciphers_(),
+        openssl_sni_hostname_(),
         openssl_options_(0),
         io_service_(),
         always_verify_peer_(false),
@@ -42,6 +43,7 @@ class client_options {
         openssl_certificate_file_(other.openssl_certificate_file_),
         openssl_private_key_file_(other.openssl_private_key_file_),
         openssl_ciphers_(other.openssl_ciphers_),
+        openssl_sni_hostname_(other.openssl_sni_hostname_),
         openssl_options_(other.openssl_options_),
         io_service_(other.io_service_),
         always_verify_peer_(other.always_verify_peer_),
@@ -61,6 +63,7 @@ class client_options {
     swap(openssl_certificate_file_, other.openssl_certificate_file_);
     swap(openssl_private_key_file_, other.openssl_private_key_file_);
     swap(openssl_ciphers_, other.openssl_ciphers_);
+    swap(openssl_sni_hostname_, other.openssl_sni_hostname_);
     swap(openssl_options_, other.openssl_options_);
     swap(io_service_, other.io_service_);
     swap(always_verify_peer_, other.always_verify_peer_);
@@ -99,6 +102,11 @@ class client_options {
 
   client_options& openssl_ciphers(string_type const& v) {
     openssl_ciphers_ = v;
+    return *this;
+  }
+
+  client_options& openssl_sni_hostname(string_type const& v) {
+    openssl_sni_hostname_ = v;
     return *this;
   }
 
@@ -146,11 +154,13 @@ class client_options {
     return openssl_ciphers_;
   }
 
+  boost::optional<string_type> openssl_sni_hostname() const {
+    return openssl_sni_hostname_;
+  }
+
   long openssl_options() const { return openssl_options_; }
 
-  std::shared_ptr<asio::io_service> io_service() const {
-    return io_service_;
-  }
+  std::shared_ptr<asio::io_service> io_service() const { return io_service_; }
 
   bool always_verify_peer() const { return always_verify_peer_; }
 
@@ -164,6 +174,7 @@ class client_options {
   boost::optional<string_type> openssl_certificate_file_;
   boost::optional<string_type> openssl_private_key_file_;
   boost::optional<string_type> openssl_ciphers_;
+  boost::optional<string_type> openssl_sni_hostname_;
   long openssl_options_;
   std::shared_ptr<asio::io_service> io_service_;
   bool always_verify_peer_;

--- a/boost/network/protocol/http/client/pimpl.hpp
+++ b/boost/network/protocol/http/client/pimpl.hpp
@@ -72,12 +72,12 @@ struct basic_client_impl
                     optional<string_type> const& verify_path,
                     optional<string_type> const& certificate_file,
                     optional<string_type> const& private_key_file,
-                    optional<string_type> const& ciphers, long ssl_options,
-                    std::shared_ptr<asio::io_service> service,
-                    int timeout)
+                    optional<string_type> const& ciphers,
+                    optional<string_type> const& sni_hostname, long ssl_options,
+                    std::shared_ptr<asio::io_service> service, int timeout)
       : base_type(cache_resolved, follow_redirect, always_verify_peer, timeout,
                   service, certificate_filename, verify_path, certificate_file,
-                  private_key_file, ciphers, ssl_options) {}
+                  private_key_file, ciphers, sni_hostname, ssl_options) {}
 
   ~basic_client_impl() = default;
 };

--- a/boost/network/protocol/http/client/sync_impl.hpp
+++ b/boost/network/protocol/http/client/sync_impl.hpp
@@ -32,7 +32,8 @@ struct sync_client
       connection_base;
   typedef typename resolver<Tag>::type resolver_type;
   typedef std::function<void(iterator_range<char const*> const&,
-                        std::error_code const&)> body_callback_function_type;
+                             std::error_code const&)>
+      body_callback_function_type;
   typedef std::function<bool(string_type&)> body_generator_function_type;
   friend struct basic_client_impl<Tag, version_major, version_minor>;
 
@@ -44,22 +45,23 @@ struct sync_client
   optional<string_type> certificate_file_;
   optional<string_type> private_key_file_;
   optional<string_type> ciphers_;
+  optional<string_type> sni_hostname_;
   long ssl_options_;
   bool always_verify_peer_;
 
   sync_client(
       bool cache_resolved, bool follow_redirect, bool always_verify_peer,
       int timeout, std::shared_ptr<asio::io_service> service,
-      optional<string_type>  certificate_filename =
-          optional<string_type>(),
-      optional<string_type>  verify_path = optional<string_type>(),
-      optional<string_type>  certificate_file = optional<string_type>(),
-      optional<string_type>  private_key_file = optional<string_type>(),
-      optional<string_type>  ciphers = optional<string_type>(),
+      optional<string_type> certificate_filename = optional<string_type>(),
+      optional<string_type> verify_path = optional<string_type>(),
+      optional<string_type> certificate_file = optional<string_type>(),
+      optional<string_type> private_key_file = optional<string_type>(),
+      optional<string_type> ciphers = optional<string_type>(),
+      optional<string_type> sni_hostname = optional<string_type>(),
       long ssl_options = 0)
       : connection_base(cache_resolved, follow_redirect, timeout),
         service_ptr(service.get() ? service
-                    : std::make_shared<asio::io_service>()),
+                                  : std::make_shared<asio::io_service>()),
         service_(*service_ptr),
         resolver_(service_),
         certificate_filename_(std::move(certificate_filename)),
@@ -67,6 +69,7 @@ struct sync_client
         certificate_file_(std::move(certificate_file)),
         private_key_file_(std::move(private_key_file)),
         ciphers_(std::move(ciphers)),
+        sni_hostname_(std::move(sni_hostname)),
         ssl_options_(ssl_options),
         always_verify_peer_(always_verify_peer) {}
 
@@ -81,7 +84,8 @@ struct sync_client
     typename connection_base::connection_ptr connection_;
     connection_ = connection_base::get_connection(
         resolver_, request_, always_verify_peer_, certificate_filename_,
-        verify_path_, certificate_file_, private_key_file_, ciphers_);
+        verify_path_, certificate_file_, private_key_file_, ciphers_,
+        sni_hostname_);
     return connection_->send_request(method, request_, get_body, callback,
                                      generator);
   }

--- a/boost/network/protocol/http/policies/async_connection.hpp
+++ b/boost/network/protocol/http/policies/async_connection.hpp
@@ -43,12 +43,13 @@ struct async_connection_policy : resolver_policy<Tag>::type {
         optional<string_type> const& verify_path,
         optional<string_type> const& certificate_file,
         optional<string_type> const& private_key_file,
-        optional<string_type> const& ciphers, long ssl_options) {
+        optional<string_type> const& ciphers,
+        optional<string_type> const& sni_hostname, long ssl_options) {
       pimpl = impl::async_connection_base<Tag, version_major, version_minor>::
           new_connection(resolve, resolver, follow_redirect, always_verify_peer,
                          https, timeout, certificate_filename, verify_path,
                          certificate_file, private_key_file, ciphers,
-                         ssl_options);
+                         sni_hostname, ssl_options);
     }
 
     basic_response<Tag> send_request(string_type /*unused*/ const& method,
@@ -74,6 +75,7 @@ struct async_connection_policy : resolver_policy<Tag>::type {
       optional<string_type> const& certificate_file = optional<string_type>(),
       optional<string_type> const& private_key_file = optional<string_type>(),
       optional<string_type> const& ciphers = optional<string_type>(),
+      optional<string_type> const& sni_hostname = optional<string_type>(),
       long ssl_options = 0) {
     string_type protocol_ = protocol(request_);
     namespace ph = std::placeholders;
@@ -85,7 +87,7 @@ struct async_connection_policy : resolver_policy<Tag>::type {
         },
         resolver, boost::iequals(protocol_, string_type("https")), timeout_,
         certificate_filename, verify_path, certificate_file, private_key_file,
-        ciphers, ssl_options);
+        ciphers, sni_hostname, ssl_options);
   }
 
   void cleanup() {}


### PR DESCRIPTION
The same notes from #601, make note of the significant changes induced by the local `.clang-format`.