### PR TITLE
Fixed multithread problem

### DIFF
--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB_RECURSE CPP-NETLIB_HEADERS
     "${CPP-NETLIB_SOURCE_DIR}/boost/" "*.hpp")
 
 set(CPP-NETLIB_URI_SRCS uri/uri.cpp uri/schemes.cpp)
+add_definitions("-DBOOST_SPIRIT_THREADSAFE")
 add_library(cppnetlib-uri ${CPP-NETLIB_URI_SRCS})
 set_target_properties(cppnetlib-uri
     PROPERTIES VERSION ${CPPNETLIB_VERSION_STRING}


### PR DESCRIPTION
the boost::spirit grammar object is not thread safe without -DBOOST_SPIRIT_THREADSAFE
see https://groups.google.com/forum/#!topic/cpp-netlib/yqa5Qtpc1j4