### PR TITLE
fix for -pedantic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,11 @@ endif()
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
   # Use C++11 when using GNU compilers.
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -std=c++11")
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   # We want to link in C++11 mode in Clang too, but also set a high enough
   # template depth for the template metaprogramming.
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -ftemplate-depth=256 -std=c++11")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -ftemplate-depth=256 -std=c++11")
   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     # Use libc++ only in OS X.
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")

--- a/boost/network/message/directives.hpp
+++ b/boost/network/message/directives.hpp
@@ -24,12 +24,12 @@ inline basic_message<Tag>& operator<<(basic_message<Tag>& message_,
 }
 
 BOOST_NETWORK_STRING_DIRECTIVE(source, source_, message.source(source_),
-                               message.source = source_);
+                               message.source = source_)
 BOOST_NETWORK_STRING_DIRECTIVE(destination, destination_,
                                message.destination(destination_),
-                               message.destination = destination_);
+                               message.destination = destination_)
 BOOST_NETWORK_STRING_DIRECTIVE(body, body_, message.body(body_),
-                               message.body = body_);
+                               message.body = body_)
 
 }  // namespace network
 

--- a/boost/network/protocol/http/message/directives/method.hpp
+++ b/boost/network/protocol/http/message/directives/method.hpp
@@ -11,7 +11,7 @@ namespace network {
 namespace http {
 
 BOOST_NETWORK_STRING_DIRECTIVE(method, method_, message.method(method_),
-                               message.method = method_);
+                               message.method = method_)
 
 } // namespace http
  /* http */

--- a/boost/network/protocol/http/message/directives/status_message.hpp
+++ b/boost/network/protocol/http/message/directives/status_message.hpp
@@ -16,7 +16,7 @@ namespace http {
 
 BOOST_NETWORK_STRING_DIRECTIVE(status_message, status_message_,
                                message.status_message(status_message_),
-                               message.status_message = status_message_);
+                               message.status_message = status_message_)
 
 }  // namespace http
 

--- a/boost/network/protocol/http/message/directives/uri.hpp
+++ b/boost/network/protocol/http/message/directives/uri.hpp
@@ -15,7 +15,7 @@ namespace network {
 namespace http {
 
 BOOST_NETWORK_STRING_DIRECTIVE(uri, uri_, message.uri(uri_),
-                               message.uri = uri_);
+                               message.uri = uri_)
 
 }  // namespace http
 

--- a/boost/network/protocol/http/message/directives/version.hpp
+++ b/boost/network/protocol/http/message/directives/version.hpp
@@ -15,7 +15,7 @@ namespace network {
 namespace http {
 
 BOOST_NETWORK_STRING_DIRECTIVE(version, version_, message.version(version_),
-                               message.version = version_);
+                               message.version = version_)
 
 }  // namespace http
 

--- a/boost/network/protocol/http/message/wrappers/destination.hpp
+++ b/boost/network/protocol/http/message/wrappers/destination.hpp
@@ -25,7 +25,7 @@ struct Request;
 template <class R>
 struct Response;
 
-BOOST_NETWORK_DEFINE_HTTP_WRAPPER(destination, destination, destination);
+BOOST_NETWORK_DEFINE_HTTP_WRAPPER(destination, destination, destination)
 
 }  // namespace http
 

--- a/boost/network/protocol/http/message/wrappers/source.hpp
+++ b/boost/network/protocol/http/message/wrappers/source.hpp
@@ -18,7 +18,7 @@ struct basic_response;
 template <class Tag>
 struct basic_request;
 
-BOOST_NETWORK_DEFINE_HTTP_WRAPPER(source, source, source);
+BOOST_NETWORK_DEFINE_HTTP_WRAPPER(source, source, source)
 
 }  // namespace http
 

--- a/boost/network/protocol/http/tags.hpp
+++ b/boost/network/protocol/http/tags.hpp
@@ -52,11 +52,11 @@ typedef mpl::vector<
     http, simple, boost::network::tags::async, boost::network::tags::pod,
     boost::network::tags::default_string, server> http_server_tags;
 
-BOOST_NETWORK_DEFINE_TAG(http_default_8bit_tcp_resolve);
-BOOST_NETWORK_DEFINE_TAG(http_default_8bit_udp_resolve);
-BOOST_NETWORK_DEFINE_TAG(http_async_8bit_udp_resolve);
-BOOST_NETWORK_DEFINE_TAG(http_async_8bit_tcp_resolve);
-BOOST_NETWORK_DEFINE_TAG(http_server);
+BOOST_NETWORK_DEFINE_TAG(http_default_8bit_tcp_resolve)
+BOOST_NETWORK_DEFINE_TAG(http_default_8bit_udp_resolve)
+BOOST_NETWORK_DEFINE_TAG(http_async_8bit_udp_resolve)
+BOOST_NETWORK_DEFINE_TAG(http_async_8bit_tcp_resolve)
+BOOST_NETWORK_DEFINE_TAG(http_server)
 
 }  // namespace tags
 }  // namespace http

--- a/boost/network/uri/uri.ipp
+++ b/boost/network/uri/uri.ipp
@@ -15,7 +15,7 @@ BOOST_FUSION_ADAPT_TPL_STRUCT(
      user_info)(boost::optional<boost::iterator_range<FwdIter> >,
                 host)(boost::optional<boost::iterator_range<FwdIter> >,
                       port)(boost::optional<boost::iterator_range<FwdIter> >,
-                            path));
+                            path))
 
 BOOST_FUSION_ADAPT_TPL_STRUCT(
     (FwdIter), (boost::network::uri::detail::uri_parts)(FwdIter),
@@ -23,7 +23,7 @@ BOOST_FUSION_ADAPT_TPL_STRUCT(
      scheme)(boost::network::uri::detail::hierarchical_part<FwdIter>,
              hier_part)(boost::optional<boost::iterator_range<FwdIter> >,
                         query)(boost::optional<boost::iterator_range<FwdIter> >,
-                               fragment));
+                               fragment))
 
 namespace boost {
 namespace network {

--- a/libs/network/example/http_client.cpp
+++ b/libs/network/example/http_client.cpp
@@ -73,7 +73,6 @@ int main(int argc, char* argv[]) {
 
   if (show_headers) {
     auto headers_ = response.headers();
-    typedef std::pair<std::string, std::string> header_type;
     for (auto const& header : headers_) {
       std::cout << header.first << ": " << header.second << std::endl;
     }

--- a/libs/network/example/twitter/rapidjson/document.h
+++ b/libs/network/example/twitter/rapidjson/document.h
@@ -566,20 +566,20 @@ private:
 	// By using proper binary layout, retrieval of different integer types do not need conversions.
 	union Number {
 #if RAPIDJSON_ENDIAN == RAPIDJSON_LITTLEENDIAN
-		struct {
+		struct A {
 			int i;
 			char padding[4];
 		};
-		struct {
+		struct B {
 			unsigned u;
 			char padding2[4];
 		};
 #else
-		struct {
+		struct A {
 			char padding[4];
 			int i;
 		};
-		struct {
+		struct B {
 			char padding2[4];
 			unsigned u;
 		};

--- a/libs/network/test/http/client_get_timeout_test.cpp
+++ b/libs/network/test/http/client_get_timeout_test.cpp
@@ -29,7 +29,7 @@ struct localhost_server_fixture {
   http_test_server server;
 };
 
-BOOST_GLOBAL_FIXTURE(localhost_server_fixture);
+BOOST_GLOBAL_FIXTURE(localhost_server_fixture)
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(http_get_test_timeout_1_0, client, client_types) {
   typename client::request request("http://localhost:12121/");

--- a/libs/network/test/utils_thread_pool.cpp
+++ b/libs/network/test/utils_thread_pool.cpp
@@ -21,7 +21,7 @@ using namespace boost::network;
 
 TEST(ThreadPoolTest, DefaultConstructor) {
   utils::thread_pool pool;
-  ASSERT_EQ(1, pool.thread_count());
+  ASSERT_EQ(1u, pool.thread_count());
 }
 
 struct foo {


### PR DESCRIPTION
cpp-netlib does not compile w/o warnings when -pedantic is enabled. it's mostly about extra semicolons. this patch fixes it.