### PR TITLE
Do not assume ipv4 for source

### DIFF
--- a/boost/network/protocol/http/server/async_connection.hpp
+++ b/boost/network/protocol/http/server/async_connection.hpp
@@ -387,7 +387,7 @@ struct async_connection
 
   void start() {
     typename ostringstream<Tag>::type ip_stream;
-    ip_stream << socket_.remote_endpoint().address().to_v4().to_string() << ':'
+    ip_stream << socket_.remote_endpoint().address().to_string() << ':'
               << socket_.remote_endpoint().port();
     request_.source = ip_stream.str();
     read_more(method);


### PR DESCRIPTION
Fixes #611 -- this does not assume that address() is always convertible to ipv4.