### PR TITLE
Fix #677: Exception in async_server_base/async_connection during port scanning (nmap)

### DIFF
--- a/boost/network/protocol/http/server/async_connection.hpp
+++ b/boost/network/protocol/http/server/async_connection.hpp
@@ -462,11 +462,18 @@ struct async_connection
   enum state_t { method, uri, version, headers };
 
   void start() {
-    typename ostringstream<Tag>::type ip_stream;
-    ip_stream << socket_.remote_endpoint().address().to_string() << ':'
-              << socket_.remote_endpoint().port();
-    request_.source = ip_stream.str();
-    read_more(method);
+    std::error_code ec;
+    auto remote_endpoint = socket_.remote_endpoint(ec);
+    
+    if (ec) {
+      error_encountered = in_place<std::system_error>(ec);
+    } else {
+      typename ostringstream<Tag>::type ip_stream;
+      ip_stream << remote_endpoint.address().to_string() << ':'
+                << remote_endpoint.port();
+      request_.source = ip_stream.str();
+      read_more(method);
+    }
   }
 
   void read_more(state_t state) {

--- a/boost/network/protocol/stream_handler.hpp
+++ b/boost/network/protocol/stream_handler.hpp
@@ -109,12 +109,21 @@ struct stream_handler {
     }
   }
 
-  tcp_socket::endpoint_type remote_endpoint() const {
+  tcp_socket::endpoint_type remote_endpoint(std::error_code& ec) const {
     if (ssl_enabled) {
-      return ssl_sock_->next_layer().remote_endpoint();
+      return ssl_sock_->next_layer().remote_endpoint(ec);
     } else {
-      return tcp_sock_->remote_endpoint();
+      return tcp_sock_->remote_endpoint(ec);
     }
+  }
+
+  tcp_socket::endpoint_type remote_endpoint() const {
+    std::error_code ec;
+    tcp_socket::endpoint_type r = remote_endpoint(ec);
+    if (ec) {
+      ::asio::detail::throw_error(ec, "remote_endpoint");
+    }
+    return r;
   }
 
   void shutdown(::asio::socket_base::shutdown_type st,


### PR DESCRIPTION
Fix for issue #677.

During a port scan `async_server_base::handle_accept()` may be called while the connection is not properly established. No error code is passed to `handel_accept()` (i.e. `!!ec == false`) but the subsequent call to `async_connection::start()` -> `stream_handler::remote_endpoint()` -> `asio::basic_socket::remote_endpoint()` fails with an exception.

My fix is to add error checking by using `asio::basic_socket::remote_endpoint(asio::error_code&)` overload in `stream_handler::remote_endpoint()` and passing the error to `async_connection::start()`.

Since i had to change signature of `stream_handler::remote_endpoint()`, i added a new overload with old signature and behavior to keep any code which uses it working.