### PR TITLE
replace std::shared_future with boost::shared_future

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_definitions(-DBOOST_TEST_DYN_LINK)
 # Always use multi-threaded Boost libraries.
 set(Boost_USE_MULTI_THREADED ON)
 
-find_package(Boost 1.58.0 REQUIRED COMPONENTS system)
+find_package(Boost 1.58.0 REQUIRED COMPONENTS system thread)
 
 if (CPP-NETLIB_ENABLE_HTTPS)
     find_package( OpenSSL )

--- a/boost/network/message/directives/detail/string_value.hpp
+++ b/boost/network/message/directives/detail/string_value.hpp
@@ -6,10 +6,10 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <boost/network/traits/string.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_sync.hpp>
+#include <boost/thread/future.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/or.hpp>
@@ -20,7 +20,7 @@ namespace detail {
 
 template <class Tag>
 struct string_value
-    : mpl::if_<is_async<Tag>, std::shared_future<typename string<Tag>::type>,
+    : mpl::if_<is_async<Tag>, boost::shared_future<typename string<Tag>::type>,
                typename mpl::if_<
                    mpl::or_<is_sync<Tag>, is_same<Tag, tags::default_string>,
                             is_same<Tag, tags::default_wstring> >,

--- a/boost/network/message/modifiers/clear_headers.hpp
+++ b/boost/network/message/modifiers/clear_headers.hpp
@@ -6,11 +6,11 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/not.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_pod.hpp>
+#include <boost/thread/future.hpp>
 #include <boost/utility/enable_if.hpp>
 
 namespace boost {
@@ -34,8 +34,8 @@ template <class Message, class Tag>
 inline typename enable_if<mpl::and_<mpl::not_<is_pod<Tag> >, is_async<Tag> >,
                           void>::type
 clear_headers(Message const &message, Tag const &) {
-  std::promise<typename Message::headers_container_type> header_promise;
-  std::shared_future<typename Message::headers_container_type> headers_future(
+  boost::promise<typename Message::headers_container_type> header_promise;
+  boost::shared_future<typename Message::headers_container_type> headers_future(
       header_promise.get_future());
   message.headers(headers_future);
   header_promise.set_value(typename Message::headers_container_type());

--- a/boost/network/message/traits/body.hpp
+++ b/boost/network/message/traits/body.hpp
@@ -8,12 +8,12 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <boost/mpl/if.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_sync.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
+#include <boost/thread/future.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 namespace boost {
@@ -27,7 +27,7 @@ template <class Message>
 struct body
     : mpl::if_<
           is_async<typename Message::tag>,
-          std::shared_future<typename string<typename Message::tag>::type>,
+          boost::shared_future<typename string<typename Message::tag>::type>,
           typename mpl::if_<
               mpl::or_<is_sync<typename Message::tag>,
                        is_same<typename Message::tag,

--- a/boost/network/message/traits/destination.hpp
+++ b/boost/network/message/traits/destination.hpp
@@ -7,12 +7,12 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <boost/mpl/if.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_sync.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
+#include <boost/thread/future.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 namespace boost {
@@ -26,7 +26,7 @@ struct unsupported_tag;
 template <class Message>
 struct destination
     : mpl::if_<is_async<typename Message::tag>,
-               std::shared_future<typename string<typename Message::tag>::type>,
+               boost::shared_future<typename string<typename Message::tag>::type>,
                typename mpl::if_<
                    mpl::or_<is_sync<typename Message::tag>,
                             is_same<typename Message::tag,

--- a/boost/network/message/traits/headers.hpp
+++ b/boost/network/message/traits/headers.hpp
@@ -7,7 +7,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/network/message/directives.hpp>
@@ -15,6 +14,7 @@
 #include <boost/network/message/wrappers.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_sync.hpp>
+#include <boost/thread/future.hpp>
 
 namespace boost {
 namespace network {
@@ -28,7 +28,7 @@ template <class Message>
 struct header_key
     : mpl::if_<
           is_async<typename Message::tag>,
-          std::shared_future<typename string<typename Message::tag>::type>,
+          boost::shared_future<typename string<typename Message::tag>::type>,
           typename mpl::if_<
               mpl::or_<is_sync<typename Message::tag>,
                        is_same<typename Message::tag, tags::default_string>,
@@ -40,7 +40,7 @@ template <class Message>
 struct header_value
     : mpl::if_<
           is_async<typename Message::tag>,
-          std::shared_future<typename string<typename Message::tag>::type>,
+          boost::shared_future<typename string<typename Message::tag>::type>,
           typename mpl::if_<
               mpl::or_<is_sync<typename Message::tag>,
                        is_same<typename Message::tag, tags::default_string>,

--- a/boost/network/message/traits/source.hpp
+++ b/boost/network/message/traits/source.hpp
@@ -6,12 +6,12 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <boost/mpl/if.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_sync.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
+#include <boost/thread/future.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 namespace boost {
@@ -24,7 +24,7 @@ struct unsupported_tag;
 template <class Message>
 struct source
     : mpl::if_<is_async<typename Message::tag>,
-               std::shared_future<typename string<typename Message::tag>::type>,
+               boost::shared_future<typename string<typename Message::tag>::type>,
                typename mpl::if_<
                    mpl::or_<is_sync<typename Message::tag>,
                             is_same<typename Message::tag,

--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -17,6 +17,7 @@
 #include <boost/network/protocol/http/parser/incremental.hpp>
 #include <boost/network/protocol/http/request_parser.hpp>
 #include <boost/network/traits/string.hpp>
+#include <boost/thread/future.hpp>
 
 namespace boost {
 namespace network {
@@ -57,30 +58,30 @@ struct http_async_protocol_handler {
     // TODO(dberris): review parameter necessity.
     (void)get_body;
 
-    std::shared_future<string_type> source_future(
+    boost::shared_future<string_type> source_future(
         source_promise.get_future());
     source(response_, source_future);
 
-    std::shared_future<string_type> destination_future(
+    boost::shared_future<string_type> destination_future(
         destination_promise.get_future());
     destination(response_, destination_future);
 
-    std::shared_future<typename headers_container<Tag>::type> headers_future(
+    boost::shared_future<typename headers_container<Tag>::type> headers_future(
         headers_promise.get_future());
     headers(response_, headers_future);
 
-    std::shared_future<string_type> body_future(body_promise.get_future());
+    boost::shared_future<string_type> body_future(body_promise.get_future());
     body(response_, body_future);
 
-    std::shared_future<string_type> version_future(
+    boost::shared_future<string_type> version_future(
         version_promise.get_future());
     version(response_, version_future);
 
-    std::shared_future<std::uint16_t> status_future(
+    boost::shared_future<std::uint16_t> status_future(
         status_promise.get_future());
     status(response_, status_future);
 
-    std::shared_future<string_type> status_message_future(
+    boost::shared_future<string_type> status_message_future(
         status_message_promise.get_future());
     status_message(response_, status_message_future);
   }
@@ -341,13 +342,13 @@ struct http_async_protocol_handler {
   typedef std::array<typename char_<Tag>::type, 1024> buffer_type;
 
   response_parser_type response_parser_;
-  std::promise<string_type> version_promise;
-  std::promise<std::uint16_t> status_promise;
-  std::promise<string_type> status_message_promise;
-  std::promise<typename headers_container<Tag>::type> headers_promise;
-  std::promise<string_type> source_promise;
-  std::promise<string_type> destination_promise;
-  std::promise<string_type> body_promise;
+  boost::promise<string_type> version_promise;
+  boost::promise<std::uint16_t> status_promise;
+  boost::promise<string_type> status_message_promise;
+  boost::promise<typename headers_container<Tag>::type> headers_promise;
+  boost::promise<string_type> source_promise;
+  boost::promise<string_type> destination_promise;
+  boost::promise<string_type> body_promise;
   buffer_type part;
   typename buffer_type::const_iterator part_begin;
   string_type partial_parsed;

--- a/boost/network/protocol/http/message/async_message.hpp
+++ b/boost/network/protocol/http/message/async_message.hpp
@@ -9,13 +9,13 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <cstdint>
 #include <boost/optional.hpp>
 
 // FIXME move this out to a trait
 #include <set>
 #include <boost/network/detail/wrapper_base.hpp>
+#include <boost/thread/future.hpp>
 
 namespace boost {
 namespace network {
@@ -56,31 +56,31 @@ struct async_message {
 
   string_type const status_message() const { return status_message_.get(); }
 
-  void status_message(std::shared_future<string_type> const& future) const {
+  void status_message(boost::shared_future<string_type> const& future) const {
     status_message_ = future;
   }
 
   string_type const version() const { return version_.get(); }
 
-  void version(std::shared_future<string_type> const& future) const {
+  void version(boost::shared_future<string_type> const& future) const {
     version_ = future;
   }
 
   std::uint16_t status() const { return status_.get(); }
 
-  void status(std::shared_future<uint16_t> const& future) const {
+  void status(boost::shared_future<uint16_t> const& future) const {
     status_ = future;
   }
 
   string_type const source() const { return source_.get(); }
 
-  void source(std::shared_future<string_type> const& future) const {
+  void source(boost::shared_future<string_type> const& future) const {
     source_ = future;
   }
 
   string_type const destination() const { return destination_.get(); }
 
-  void destination(std::shared_future<string_type> const& future) const {
+  void destination(boost::shared_future<string_type> const& future) const {
     destination_ = future;
   }
 
@@ -95,7 +95,7 @@ struct async_message {
     return *retrieved_headers_;
   }
 
-  void headers(std::shared_future<headers_container_type> const& future)
+  void headers(boost::shared_future<headers_container_type> const& future)
       const {
     headers_ = future;
   }
@@ -112,7 +112,7 @@ struct async_message {
 
   string_type const body() const { return body_.get(); }
 
-  void body(std::shared_future<string_type> const& future) const {
+  void body(boost::shared_future<string_type> const& future) const {
     body_ = future;
   }
 
@@ -132,13 +132,13 @@ struct async_message {
   }
 
  private:
-  mutable std::shared_future<string_type> status_message_, version_, source_,
+  mutable boost::shared_future<string_type> status_message_, version_, source_,
       destination_;
-  mutable std::shared_future<std::uint16_t> status_;
-  mutable std::shared_future<headers_container_type> headers_;
+  mutable boost::shared_future<std::uint16_t> status_;
+  mutable boost::shared_future<headers_container_type> headers_;
   mutable headers_container_type added_headers;
   mutable std::set<string_type> removed_headers;
-  mutable std::shared_future<string_type> body_;
+  mutable boost::shared_future<string_type> body_;
   mutable boost::optional<headers_container_type> retrieved_headers_;
 
   friend struct boost::network::http::impl::ready_wrapper<Tag>;

--- a/boost/network/protocol/http/message/directives/status.hpp
+++ b/boost/network/protocol/http/message/directives/status.hpp
@@ -7,11 +7,11 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <cstdint>
 #include <boost/mpl/if.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/tags.hpp>
+#include <boost/thread/future.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant.hpp>
@@ -25,18 +25,18 @@ struct basic_response;
 
 struct status_directive {
 
-  boost::variant<std::uint16_t, std::shared_future<std::uint16_t> >
+  boost::variant<std::uint16_t, boost::shared_future<std::uint16_t> >
       status_;
 
   explicit status_directive(std::uint16_t status) : status_(status) {}
 
-  explicit status_directive(std::shared_future<std::uint16_t> const &status)
+  explicit status_directive(boost::shared_future<std::uint16_t> const &status)
       : status_(status) {}
 
   status_directive(status_directive const &other) : status_(other.status_) {}
 
   template <class Tag>
-  struct value : mpl::if_<is_async<Tag>, std::shared_future<std::uint16_t>,
+  struct value : mpl::if_<is_async<Tag>, boost::shared_future<std::uint16_t>,
                           std::uint16_t> {};
 
   template <class Tag>

--- a/boost/network/protocol/http/message/traits/status.hpp
+++ b/boost/network/protocol/http/message/traits/status.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/tags.hpp>
+#include <boost/thread/future.hpp>
 
 namespace boost {
 namespace network {
@@ -23,7 +24,7 @@ template <class Message>
 struct status
     : mpl::if_<
           is_async<typename Message::tag>,
-          std::shared_future<std::uint16_t>,
+          boost::shared_future<std::uint16_t>,
           typename mpl::if_<is_sync<typename Message::tag>, std::uint16_t,
                             unsupported_tag<typename Message::tag> >::type> {};
 

--- a/boost/network/protocol/http/message/traits/status_message.hpp
+++ b/boost/network/protocol/http/message/traits/status_message.hpp
@@ -6,11 +6,11 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <boost/mpl/if.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
+#include <boost/thread/future.hpp>
 
 namespace boost {
 namespace network {
@@ -25,7 +25,7 @@ template <class Message>
 struct status_message
     : mpl::if_<
           is_async<typename Message::tag>,
-          std::shared_future<typename string<typename Message::tag>::type>,
+          boost::shared_future<typename string<typename Message::tag>::type>,
           typename mpl::if_<
               mpl::or_<is_sync<typename Message::tag>,
                        is_same<typename Message::tag, boost::network::tags::default_string>,

--- a/boost/network/protocol/http/message/traits/version.hpp
+++ b/boost/network/protocol/http/message/traits/version.hpp
@@ -6,12 +6,12 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <future>
 #include <boost/mpl/or.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_sync.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
+#include <boost/thread/future.hpp>
 
 namespace boost {
 namespace network {
@@ -30,7 +30,7 @@ struct version {
 template <class Message>
 struct version<Message,
                typename enable_if<is_async<typename Message::tag> >::type> {
-  typedef std::shared_future<typename string<typename Message::tag>::type>
+  typedef boost::shared_future<typename string<typename Message::tag>::type>
       type;
 };
 

--- a/libs/network/doc/reference/http_response.rst
+++ b/libs/network/doc/reference/http_response.rst
@@ -307,3 +307,7 @@ effect:
 ``template <class Tag>`` *unspecified* ``status_message(basic_response<Tag> const & response)``
     Returns a wrapper convertible to ``typename string<Tag>::type`` that
     provides the status message of the given response.
+``template <class Tag>`` *unspecified* ``ready(basic_response<Tag> const & response)``
+    Returns a wrapper convertible to ``bool``.  The return value is equivalent
+    to ``true`` if all the response parts have been fetched and it is guaranteed
+    that a successive call to any wrapper will not block.

--- a/libs/network/test/http/CMakeLists.txt
+++ b/libs/network/test/http/CMakeLists.txt
@@ -38,6 +38,7 @@ if (Boost_FOUND)
       client_get_test
       client_get_different_port_test
       # client_get_timeout_test
+      client_get_ready_test
       client_get_streaming_test)
     foreach ( test ${TESTS} )
         add_executable(cpp-netlib-http-${test} ${test}.cpp)

--- a/libs/network/test/http/client_get_ready_test.cpp
+++ b/libs/network/test/http/client_get_ready_test.cpp
@@ -1,0 +1,34 @@
+// Copyright 2010 Dean Michael Berris.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <gtest/gtest.h>
+#include <boost/network/include/http/client.hpp>
+#include "client_types.hpp"
+
+namespace net = boost::network;
+namespace http = boost::network::http;
+using tclock = std::chrono::high_resolution_clock;
+
+TYPED_TEST_CASE(HTTPClientTest, ClientTypes);
+
+TYPED_TEST(HTTPClientTest, GetTest) {
+  using client = TypeParam;
+  typename client::request request("http://cpp-netlib.org/");
+  client client_;
+  auto response = client_.get(request);
+  while (!http::ready(response)) {
+	  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  auto t0 = tclock::now();
+  auto data = body(response);
+  auto t1 = tclock::now();
+  EXPECT_TRUE(response.status() == 200u ||
+              (response.status() >= 300 && response.status() < 400));
+  EXPECT_TRUE(data.size() > 0);
+
+  // XXX we should find a better way to check if `ready()` has done his job
+  namespace c = std::chrono;
+  EXPECT_TRUE(c::duration_cast<c::milliseconds>(t1-t0).count() < 1);
+}


### PR DESCRIPTION
This PR replaces std::promise and std::shared_future with boost equivalents.

This change fixes the compilation errors when the `ready()` wrapper is used.

I've added a test and a few words of documentation.

This should address #683 and #592 