### PR TITLE
OSX: fix OpenSSL detection for 10.11. Fixes #690

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,15 @@ set(Boost_USE_MULTI_THREADED ON)
 find_package(Boost 1.58.0 REQUIRED COMPONENTS system thread)
 
 if (CPP-NETLIB_ENABLE_HTTPS)
-    find_package( OpenSSL )
+  if (APPLE)
+    # If we're on OS X check for Homebrew's copy of OpenSSL instead of Apple's
+    if (NOT OpenSSL_DIR)
+      execute_process (COMMAND brew --prefix openssl
+        OUTPUT_VARIABLE OPENSSL_ROOT_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
+  endif()
+  find_package(OpenSSL)
 endif()
 
 find_package( Threads )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,15 +49,23 @@ set(Boost_USE_MULTI_THREADED ON)
 find_package(Boost 1.58.0 REQUIRED COMPONENTS system thread)
 
 if (CPP-NETLIB_ENABLE_HTTPS)
-  if (APPLE)
-    # If we're on OS X check for Homebrew's copy of OpenSSL instead of Apple's
-    if (NOT OpenSSL_DIR)
-      execute_process (COMMAND brew --prefix openssl
-        OUTPUT_VARIABLE OPENSSL_ROOT_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    endif()
-  endif()
-  find_package(OpenSSL)
+ if (APPLE)
+   # If we're on OS X check for Homebrew's copy of OpenSSL instead of Apple's
+   if (NOT OpenSSL_DIR)
+     find_program(HOMEBREW brew)
+     if (HOMEBREW STREQUAL "HOMEBREW-NOTFOUND")
+       message(WARNING "Homebrew not found: not using Homebrew's OpenSSL")
+       if (NOT OPENSSL_ROOT_DIR)
+         message(WARNING "Use -DOPENSSL_ROOT_DIR for non-Apple OpenSSL")
+       endif()
+     else()
+       execute_process(COMMAND brew --prefix openssl
+         OUTPUT_VARIABLE OPENSSL_ROOT_DIR
+         OUTPUT_STRIP_TRAILING_WHITESPACE)
+     endif()
+   endif()
+ endif()
+ find_package(OpenSSL)
 endif()
 
 find_package( Threads )


### PR DESCRIPTION
This is a confirmed fix for #690 and also confirmed to work on 10.9.5 (this should work on 10.10 as well).

The problem with this fix is the assumption that the user is using homebrew. If we shouldn't enforce this requisite, I'm open to ideas for an alternate fix.