### PR TITLE
Build: fix MinGW-w64 various undefined references

### DIFF
--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -46,6 +46,10 @@ target_link_libraries(cppnetlib-client-connections ${Boost_LIBRARIES} ${CMAKE_TH
 if (OPENSSL_FOUND)
     target_link_libraries(cppnetlib-client-connections ${OPENSSL_LIBRARIES})
 endif ()
+if (MINGW)
+    target_link_libraries(cppnetlib-client-connections ws2_32)
+endif ()
+
 install(TARGETS cppnetlib-client-connections
     EXPORT cppnetlibTargets
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}


### PR DESCRIPTION
Fixes #675 and #704. This patch may also help with #597