### PR TITLE
Update server_request_parsers_impl.cpp

### DIFF
--- a/libs/network/src/server_request_parsers_impl.cpp
+++ b/libs/network/src/server_request_parsers_impl.cpp
@@ -6,6 +6,8 @@
 
 #include <tuple>
 #include <vector>
+#include <cstdint>
+
 #define BOOST_SPIRIT_UNICODE
 #include <boost/spirit/include/qi.hpp>
 #include <boost/fusion/include/std_tuple.hpp>


### PR DESCRIPTION
VC2013 complains that "std::uint8_t" is not defined, it compiles ok after including <cstdint> header.