### PR TITLE
fix VS2013 compile issues

### DIFF
--- a/boost/network/message.hpp
+++ b/boost/network/message.hpp
@@ -37,9 +37,9 @@ struct basic_message {
 
   basic_message() = default;
   basic_message(const basic_message&) = default;
-  basic_message(basic_message&&) = default;
+  //basic_message(basic_message&&) = default;
   basic_message& operator=(basic_message const&) = default;
-  basic_message& operator=(basic_message&&) = default;
+  //basic_message& operator=(basic_message&&) = default;
   ~basic_message() = default;
 
   void swap(basic_message<Tag>& other) {

--- a/boost/network/protocol/http/client/async_impl.hpp
+++ b/boost/network/protocol/http/client/async_impl.hpp
@@ -66,7 +66,7 @@ struct async_client
       lifetime_thread_.reset(new std::thread([this]() { service_.run(); }));
   }
 
-  ~async_client() throw() = default;
+  ~async_client() = default;
 
   void wait_complete() {
     sentinel_.reset();


### PR DESCRIPTION
To compile in VS2013, maybe we should check **_MSC_VER** or simply discontinue VS2013 support.