### PR TITLE
Update Travis Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,19 @@ env:
 - BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" Uri_BUILD_TESTS=OFF Uri_DISABLE_LIBCXX=YES
 - BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="OFF" Uri_BUILD_TESTS=OFF Uri_DISABLE_LIBCXX=YES
 # Support the sanitizers in clang only
-# - BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=thread"
-# - BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=address"
+- BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=thread"
+- BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=address"
 # TODO(deanberris): It seems Boost is not msan-clean yet; report bugs and maybe fix?
 #- BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2"
-# matrix:
-#   exclude:
-#     - compiler: g++
-#       env: BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=thread"
-#     - compiler: g++
-#       env: BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=address"
+ matrix:
+   exclude:
+     - compiler: g++
+       env: BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=thread"
+     - compiler: g++
+       env: BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=address"
 # TODO(deanberris): It seems Boost is not msan-clean yet; report bugs and maybe fix?
 #    - compiler: g++
 #      env: BOOST_VER=1.59.0 BUILD_SHARED_LIBS="OFF" CMAKE_BUILD_TYPE="Debug" ENABLE_HTTPS="ON" CMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2"
-install:
-- mkdir -p ${HOME}/bin
-- if [ "${CC}" = "gcc" ]; then export TOOLSET="gcc"; ln -s `which g++-4.8` ${HOME}/bin/g++;
-  ln -s `which gcc-4.8` ${HOME}/bin/gcc; fi
-- if [ "${CC}" = "clang" ]; then export TOOLSET="clang"; ln -s `which clang-3.6` ${HOME}/bin/clang;
-  ln -s `which clang++-3.6` ${HOME}/bin/clang++; fi
-- export BOOST_VERSION=${BOOST_VER//./_}
-- export PATH=${HOME}/bin:${PATH}
-- travis_wait ./install-boost.sh
-- export BOOST_ROOT=${HOME}/${CC}-boost_${BOOST_VER//./_}
-- "${CXX} --version"
-cache:
-  directories:
-  - "${HOME}/${CC}-boost_${BOOST_VER//./_}"
 script:
 - pwd
 - sh -x build.sh
@@ -49,13 +35,15 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.6
+    - llvm-toolchain-precise-3.8
     - kalakris-cmake
+    - precise
     packages:
     - gcc-4.8
     - g++-4.8
-    - clang-3.6
+    - clang-3.8
     - cmake
+    - libboost1.62-all-dev
 notifications:
   slack:
     secure: Y7lLjqZ83+b/jaJ5+EKwvgCDeERi4bVbDn9tLp8sieTdu+ENsPI+JmLYSXZXPpe7JrItrXW6uJJXN2wG1h7au4mpVVTghd31HBzuzrqVxDphWPhp16NYzvbAgQQRBXvFVvfSdW/Kb/n2fX6xDApY0t6vNREb/GKg0GyzESb4ZjU=


### PR DESCRIPTION
Use the available precise-packaged Boost installable package, instead
of having to build it ourselves and caching it.

We also upgrade to use clang-3.8, as well as re-enable the sanitizer
builds.