### PR TITLE
Build: allow options to use Boost + OpenSSL static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ option( CPP-NETLIB_BUILD_TESTS "Build the cpp-netlib project tests." ON)
 # option( CPP-NETLIB_BUILD_EXPERIMENTS "Build the cpp-netlib project experiments." ON)
 option( CPP-NETLIB_BUILD_EXAMPLES "Build the cpp-netlib project examples." ON)
 option( CPP-NETLIB_ENABLE_HTTPS "Build cpp-netlib with support for https if OpenSSL is found." ON)
+option( CPP-NETLIB_STATIC_OPENSSL "Build cpp-netlib using static OpenSSL" OFF)
+option( CPP-NETLIB_STATIC_BOOST "Build cpp-netlib using static Boost" OFF)
 
 include(GNUInstallDirs)
 
@@ -37,8 +39,10 @@ else()
   set(BUILD_SHARED_LIBS OFF)
 endif()
 
-# Always use Boost's shared libraries.
-set(Boost_USE_STATIC_LIBS OFF)
+# Use Boost's static libraries
+if (CPP-NETLIB_STATIC_BOOST)
+  set(Boost_USE_STATIC_LIBS ON)
+endif()
 
 # We need this for all tests to use the dynamic version.
 add_definitions(-DBOOST_TEST_DYN_LINK)
@@ -64,6 +68,9 @@ if (CPP-NETLIB_ENABLE_HTTPS)
          OUTPUT_STRIP_TRAILING_WHITESPACE)
      endif()
    endif()
+ endif()
+ if (CPP-NETLIB_STATIC_OPENSSL)
+   set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
  endif()
  find_package(OpenSSL)
 endif()

--- a/libs/network/src/CMakeLists.txt
+++ b/libs/network/src/CMakeLists.txt
@@ -45,6 +45,11 @@ set_target_properties(cppnetlib-client-connections
 target_link_libraries(cppnetlib-client-connections ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 if (OPENSSL_FOUND)
     target_link_libraries(cppnetlib-client-connections ${OPENSSL_LIBRARIES})
+    if (CPP-NETLIB_STATIC_OPENSSL)
+      if (NOT MSVC AND NOT MINGW AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD") # dynlinker functions are built into libc on FreeBSD
+        target_link_libraries(cppnetlib-client-connections "-ldl")
+      endif()
+    endif()
 endif ()
 if (MINGW)
     target_link_libraries(cppnetlib-client-connections ws2_32)


### PR DESCRIPTION
Though usually not encouraged, there are use-cases for linking openssl statically (windows without openssl installed, static apps, etc.) and, though it's not as much of a security issue, the same use-cases apply to boost (so static apps don't end up linking boost dynamically because of cpp-netlib).

Default is `OFF` for both options (as I think it should be since those who need it will know when to use it).