### PR TITLE
http_async_protocol_handler: use unsigned type for content length

### DIFF
--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -416,7 +416,7 @@ struct http_async_protocol_handler {
   bool is_chunk_encoding;
   bool is_chunk_end;
   bool is_content_length;
-  long long content_length;
+  long long unsigned content_length;
 };
 
 }  // namespace impl


### PR DESCRIPTION
Resolves comparison between signed and unsigned integer expressions

References #721