### PR TITLE
boost: Use make_optional for boost 1.63

### DIFF
--- a/boost/network/protocol/http/client/options.hpp
+++ b/boost/network/protocol/http/client/options.hpp
@@ -91,39 +91,39 @@ class client_options {
   /// Set the filename of the certificate to load for the SSL connection for
   /// verification.
   client_options& openssl_certificate(string_type const& v) {
-    openssl_certificate_ = v;
+    openssl_certificate_ = make_optional(v);
     return *this;
   }
 
   /// Set the directory for which the certificate authority files are located.
   client_options& openssl_verify_path(string_type const& v) {
-    openssl_verify_path_ = v;
+    openssl_verify_path_ = make_optional(v);
     return *this;
   }
 
   /// Set the filename of the certificate to use for client-side SSL session
   /// establishment.
   client_options& openssl_certificate_file(string_type const& v) {
-    openssl_certificate_file_ = v;
+    openssl_certificate_file_ = make_optional(v);
     return *this;
   }
 
   /// Set the filename of the private key to use for client-side SSL session
   /// establishment.
   client_options& openssl_private_key_file(string_type const& v) {
-    openssl_private_key_file_ = v;
+    openssl_private_key_file_ = make_optional(v);
     return *this;
   }
 
   /// Set the ciphers to support for SSL negotiation.
   client_options& openssl_ciphers(string_type const& v) {
-    openssl_ciphers_ = v;
+    openssl_ciphers_ = make_optional(v);
     return *this;
   }
 
   /// Set the hostname for SSL SNI hostname support.
   client_options& openssl_sni_hostname(string_type const& v) {
-    openssl_sni_hostname_ = v;
+    openssl_sni_hostname_ = make_optional(v);
     return *this;
   }
 

--- a/boost/network/protocol/http/message/async_message.hpp
+++ b/boost/network/protocol/http/message/async_message.hpp
@@ -91,7 +91,7 @@ struct async_message {
     for (string_type const & key : removed_headers) {
       raw_headers.erase(key);
     }
-    retrieved_headers_ = raw_headers;
+    retrieved_headers_ = make_optional(raw_headers);
     return *retrieved_headers_;
   }
 

--- a/boost/network/uri/detail/uri_parts.hpp
+++ b/boost/network/uri/detail/uri_parts.hpp
@@ -29,27 +29,27 @@ struct hierarchical_part {
   void update() {
     if (!user_info) {
       if (host) {
-        user_info = iterator_range<FwdIter>(std::begin(host.get()),
-                                            std::begin(host.get()));
+        user_info = make_optional(iterator_range<FwdIter>(std::begin(host.get()),
+                                            std::begin(host.get())));
       } else if (path) {
-        user_info = iterator_range<FwdIter>(std::begin(path.get()),
-                                            std::begin(path.get()));
+        user_info = make_optional(iterator_range<FwdIter>(std::begin(path.get()),
+                                            std::begin(path.get())));
       }
     }
 
     if (!host) {
-      host = iterator_range<FwdIter>(std::begin(path.get()),
-                                     std::begin(path.get()));
+      host = make_optional(iterator_range<FwdIter>(std::begin(path.get()),
+                                     std::begin(path.get())));
     }
 
     if (!port) {
-      port = iterator_range<FwdIter>(std::end(host.get()),
-                                     std::end(host.get()));
+      port = make_optional(iterator_range<FwdIter>(std::end(host.get()),
+                                     std::end(host.get())));
     }
 
     if (!path) {
-      path = iterator_range<FwdIter>(std::end(port.get()),
-                                     std::end(port.get()));
+      path = make_optional(iterator_range<FwdIter>(std::end(port.get()),
+                                     std::end(port.get())));
     }
   }
 };
@@ -70,13 +70,13 @@ struct uri_parts {
     hier_part.update();
 
     if (!query) {
-      query = iterator_range<FwdIter>(std::end(hier_part.path.get()),
-                                      std::end(hier_part.path.get()));
+      query = make_optional(iterator_range<FwdIter>(std::end(hier_part.path.get()),
+                                      std::end(hier_part.path.get())));
     }
 
     if (!fragment) {
-      fragment = iterator_range<FwdIter>(std::end(query.get()),
-                                         std::end(query.get()));
+      fragment = make_optional(iterator_range<FwdIter>(std::end(query.get()),
+                                         std::end(query.get())));
     }
   }
 };


### PR DESCRIPTION
I'm not sure if this is complete in the sense that all the ambiguous `operator=` `boost::optional` usages have been converted to `make_optional`, but it allows https://github/facebook/osquery to compile when using Boost 1.63. :) 