### PR TITLE
ipv6: Allow IPv6 and HTTPS async connections

### DIFF
--- a/boost/network/protocol/http/client/connection/ssl_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.ipp
@@ -64,7 +64,10 @@ void boost::network::http::impl::ssl_delegate::connect(
     context_->use_private_key_file(*private_key_file_, boost::asio::ssl::context::pem);
 
   tcp_socket_.reset(new boost::asio::ip::tcp::socket(
-      service_, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), source_port)));
+      service_, boost::asio::ip::tcp::endpoint(endpoint.address().is_v4()
+                                                   ? boost::asio::ip::tcp::v4()
+                                                   : boost::asio::ip::tcp::v6(),
+                                               source_port)));
   socket_.reset(new boost::asio::ssl::stream<boost::asio::ip::tcp::socket &>(
       *(tcp_socket_.get()), *context_));
 


### PR DESCRIPTION
I noticed IPv6-only hosts cannot use the netlib for `https://` URIs, tracked it down to this small bug. The endpoint protocol should be based on the results of the resolver, which takes the source host's stack + resolver's own priority into account.