### PR TITLE
content_length type comparison error

### DIFF
--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -348,9 +348,9 @@ struct http_async_protocol_handler {
     }
     return false;
   }
-  
+
   inline bool parse_content_length_complete() const {
-    return this->partial_parsed.length() >= this-> content_length;
+    return static_cast<std::ptrdiff_t>(this->partial_parsed.length()) >= this->content_length;
   }
 
   bool parse_chunk_encoding_complete() const {


### PR DESCRIPTION
Type was std::size_t and was changed to long long in commit f8ff77d3ee795c32c51b904583e1b04a8b7a071e. It is also initialized to
-1 in parse_headers_real(...) to help determine parse error.

Signed-off-by: Edward Kigwana <ekigwana@gmail.com>