### PR TITLE
fix http client body content

### DIFF
--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -389,7 +389,7 @@ struct http_async_protocol_handler {
     partial_parsed.append(part_begin, part_begin + bytes);
     part_begin = part.begin();
     if (check_parse_body_complete()) {
-      callback(boost::asio::error::eof, bytes);
+      callback(boost::asio::error::eof, 0);
     } else {
       delegate_->read_some(
           boost::asio::mutable_buffers_1(part.data(), part.size()), callback);


### PR DESCRIPTION
This is a bug,introduced by my last PR #713 , I'm very sorry!!
partial_parsed buffer will append part buffer twice in function parse_body and handle_received_data.
eg.
```c
void request(std::string url)
{
    client::options options;
    options.remove_chunk_markers(true);
    client::request request_(url);
    request_ << header("Connection", "close");
    client client_(options);
    client::response response_ = client_.get(request_);
    std::string body_ = body(response_);
    printf("body len : %d\n", body_.length());
    printf("body  : %s\n", body_.c_str());
}

int main()
{
    request("http://www.google.com.cn");
    return 0;
}

cpp-netlib master output:
[irteam@dev-chenzhaoyu1.ncl cpplibtest]$ ./net_lib_client 
body len : 436
body  : <HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.cn/">here</A>.
</BODY></HTML>
HTTP/1.1 301 Moved Permanently
Location: http://www.google.cn/
Content-Type: text/html; charset=UTF-8
Date: Wed, 17 May 2017 06:00:28 GMT
Expires: Fri, 16 Jun 2017 06:00:28 GMT
Cache-Control: public, max-age=25920
net_lib_client: /usr/local/include/boost/network/protocol/http/client/connection/async_normal.hpp:89: boost::iterator_range<typename std::array<typename char_<Tag>::type, 1024>::const_iterator> boost::network::http::impl::chunk_encoding_parser<boost::network::http::tags::http_async_8bit_udp_resolve>::operator()(const boost::iterator_range<typename std::array<typename char_<Tag>::type, 1024>::const_iterator> &) [Tag = boost::network::http::tags::http_async_8bit_udp_resolve]: Assertion `*iter == '\r'' failed.
Aborted

fixed output:
[irteam@dev-chenzhaoyu1.ncl cpplibtest]$ ./net_lib_client 
body len : 218
body  : <HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.cn/">here</A>.
</BODY></HTML>

```