### PR TITLE
Request sni hostname

### DIFF
--- a/boost/network/protocol/http/client/connection/connection_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/connection_delegate.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/streambuf.hpp>
+#include <boost/optional.hpp>
 
 namespace boost {
 namespace network {
@@ -19,7 +20,7 @@ namespace impl {
 
 struct connection_delegate {
   virtual void connect(boost::asio::ip::tcp::endpoint &endpoint, std::string host,
-                       std::uint16_t source_port,
+                       std::uint16_t source_port, optional<std::string> sni_hostname,
                        std::function<void(boost::system::error_code const &)> handler) = 0;
   virtual void write(
       boost::asio::streambuf &command_streambuf,

--- a/boost/network/protocol/http/client/connection/normal_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/normal_delegate.hpp
@@ -25,7 +25,7 @@ struct normal_delegate : connection_delegate {
   explicit normal_delegate(boost::asio::io_service &service);
 
   void connect(boost::asio::ip::tcp::endpoint &endpoint, std::string host,
-               std::uint16_t source_port,
+               std::uint16_t source_port, optional<std::string> sni_hostname,
                std::function<void(boost::system::error_code const &)> handler) override;
   void write(boost::asio::streambuf &command_streambuf,
              std::function<void(boost::system::error_code const &, size_t)> handler)

--- a/boost/network/protocol/http/client/connection/normal_delegate.ipp
+++ b/boost/network/protocol/http/client/connection/normal_delegate.ipp
@@ -21,7 +21,7 @@ boost::network::http::impl::normal_delegate::normal_delegate(
 
 void boost::network::http::impl::normal_delegate::connect(
     boost::asio::ip::tcp::endpoint &endpoint, std::string host,
-    std::uint16_t source_port,
+    std::uint16_t source_port, optional<std::string> sni_hostname,
     std::function<void(boost::system::error_code const &)> handler) {
 
   // TODO(dberris): review parameter necessity.

--- a/boost/network/protocol/http/client/connection/ssl_delegate.hpp
+++ b/boost/network/protocol/http/client/connection/ssl_delegate.hpp
@@ -33,7 +33,7 @@ struct ssl_delegate : public connection_delegate,
                optional<std::string> sni_hostname, long ssl_options);
 
   void connect(boost::asio::ip::tcp::endpoint &endpoint, std::string host,
-               std::uint16_t source_port,
+               std::uint16_t source_port, optional<std::string> sni_hostname,
                std::function<void(boost::system::error_code const &)> handler) override;
   void write(
       boost::asio::streambuf &command_streambuf,

--- a/boost/network/protocol/http/impl/request.hpp
+++ b/boost/network/protocol/http/impl/request.hpp
@@ -50,29 +50,32 @@ namespace http {
  */
 template <class Tag>
 struct basic_request : public basic_message<Tag> {
-  mutable boost::network::uri::uri uri_;
-  std::uint16_t source_port_;
-  typedef basic_message<Tag> base_type;
-
  public:
   typedef Tag tag;
   typedef typename string<tag>::type string_type;
   typedef std::uint16_t port_type;
 
+ private:
+  mutable boost::network::uri::uri uri_;
+  std::uint16_t source_port_;
+  optional<string_type> sni_hostname_;
+  typedef basic_message<Tag> base_type;
+
+ public:
   explicit basic_request(string_type const& uri_)
-      : uri_(uri_), source_port_(0) {}
+      : uri_(uri_), source_port_(0), sni_hostname_() {}
 
   explicit basic_request(boost::network::uri::uri const& uri_)
-      : uri_(uri_), source_port_(0) {}
+      : uri_(uri_), source_port_(0), sni_hostname_() {}
 
   void uri(string_type const& new_uri) { uri_ = new_uri; }
 
   void uri(boost::network::uri::uri const& new_uri) { uri_ = new_uri; }
 
-  basic_request() : base_type(), source_port_(0) {}
+  basic_request() : base_type(), source_port_(0), sni_hostname_() {}
 
   basic_request(basic_request const& other)
-      : base_type(other), uri_(other.uri_), source_port_(other.source_port_) {}
+      : base_type(other), uri_(other.uri_), source_port_(other.source_port_), sni_hostname_(other.sni_hostname_) {}
 
   basic_request& operator=(basic_request rhs) {
     rhs.swap(*this);
@@ -85,6 +88,7 @@ struct basic_request : public basic_message<Tag> {
     base_ref.swap(this_ref);
     boost::swap(other.uri_, this->uri_);
     boost::swap(other.source_port_, this->source_port_);
+    boost::swap(other.sni_hostname_, this->sni_hostname_);
   }
 
   string_type const host() const { return uri_.host(); }
@@ -114,6 +118,10 @@ struct basic_request : public basic_message<Tag> {
   void source_port(const std::uint16_t port) { source_port_ = port; }
 
   std::uint16_t source_port() const { return source_port_; }
+
+  void sni_hostname(string_type const &sni_hostname) { sni_hostname_ = sni_hostname; }
+
+  const optional<string_type> &sni_hostname() const { return sni_hostname_; }
 };
 
 /** This is the implementation of a POD request type

--- a/libs/network/test/http/client_get_test.cpp
+++ b/libs/network/test/http/client_get_test.cpp
@@ -70,40 +70,27 @@ TYPED_TEST(HTTPClientTest, TemporaryClientObjectTest) {
 typedef boost::network::http::basic_client<boost::network::http::tags::http_async_8bit_tcp_resolve, 1, 1> async_client;
 #define EXC_PTR(cmd) try { cmd } catch (const std::exception_ptr& ex) { std::rethrow_exception(ex); }
 
-TYPED_TEST(HTTPClientTest, ReuseResponse) {
+TYPED_TEST(HTTPClientTest, GetRequestSNI) {
+  using client = TypeParam;
+  // need sni_hostname to be set
+  typename client::request request("https://www.guide-du-chien.com/wp-content/uploads/2016/10/Beagle.jpg");
+  typename client::response response;
 
-  async_client client;
+  // trying without setting sni_hostname
+  ASSERT_NO_THROW(response = client().get(request));
+  // raise "tlsv1 alert internal error"
+  ASSERT_THROW(response.status(), std::exception_ptr);
 
-  async_client::request req("https://static.deepomatic.com/compass/NVR_ch2_J_20161209122514_20161209122514_orig.jpg");
+  // setting sni_hostname
+  request.sni_hostname(request.host());
+  ASSERT_NO_THROW(response = client().get(request));
+  EXPECT_EQ(200u, response.status());
 
-  req.sni_hostname(req.host());
-
-  auto response = client.get(req);
-
-  while (!ready(response));
-
-  EXC_PTR(response.status(););
-
-  // we get the expected headers and body
-  auto hdrs = headers(response);
-
-  for (auto &h : hdrs) {
-      std::cout << h.first << ": " << h.second << std::endl;
-  }
-
-  std::cout << "---" << std::endl;
-
-  req.uri("http://example.com"); // changing the url
-
-  response = client.get(req);
-
-  while (!ready(response));
-
-  // here the headers are the same as the previous response, they should be those from example.com
-  auto hdrs2 = headers(response);
-
-  for (auto &h : hdrs2) {
-      std::cout << h.first << ": " << h.second << std::endl;
+  try {
+    auto data = body(response);
+    std::cout << "Body size: " << data.size() << std::endl;
+  } catch (...) {
+    FAIL() << "Caught exception while retrieving body from GET request";
   }
 
 }

--- a/libs/network/test/http/client_get_test.cpp
+++ b/libs/network/test/http/client_get_test.cpp
@@ -65,3 +65,45 @@ TYPED_TEST(HTTPClientTest, TemporaryClientObjectTest) {
   EXPECT_TRUE(response.status() == 200u ||
               (response.status() >= 300 && response.status() < 400));
 }
+
+
+typedef boost::network::http::basic_client<boost::network::http::tags::http_async_8bit_tcp_resolve, 1, 1> async_client;
+#define EXC_PTR(cmd) try { cmd } catch (const std::exception_ptr& ex) { std::rethrow_exception(ex); }
+
+TYPED_TEST(HTTPClientTest, ReuseResponse) {
+
+  async_client client;
+
+  async_client::request req("https://static.deepomatic.com/compass/NVR_ch2_J_20161209122514_20161209122514_orig.jpg");
+
+  req.sni_hostname(req.host());
+
+  auto response = client.get(req);
+
+  while (!ready(response));
+
+  EXC_PTR(response.status(););
+
+  // we get the expected headers and body
+  auto hdrs = headers(response);
+
+  for (auto &h : hdrs) {
+      std::cout << h.first << ": " << h.second << std::endl;
+  }
+
+  std::cout << "---" << std::endl;
+
+  req.uri("http://example.com"); // changing the url
+
+  response = client.get(req);
+
+  while (!ready(response));
+
+  // here the headers are the same as the previous response, they should be those from example.com
+  auto hdrs2 = headers(response);
+
+  for (auto &h : hdrs2) {
+      std::cout << h.first << ": " << h.second << std::endl;
+  }
+
+}

--- a/libs/network/test/http/client_get_test.cpp
+++ b/libs/network/test/http/client_get_test.cpp
@@ -46,30 +46,6 @@ TYPED_TEST(HTTPClientTest, GetHTTPSTest) {
   }
 }
 
-#endif
-
-TYPED_TEST(HTTPClientTest, TemporaryClientObjectTest) {
-  using client = TypeParam;
-  typename client::request request("http://cpp-netlib.org/");
-  typename client::response response;
-  ASSERT_NO_THROW(response = client().get(request));
-  auto range = headers(response);
-  ASSERT_TRUE(!boost::empty(range));
-  try {
-    auto data = body(response);
-    std::cout << data;
-  } catch (...) {
-    FAIL() << "Caught exception while retrieving body from GET request";
-  }
-  EXPECT_EQ("HTTP/1.", response.version().substr(0, 7));
-  EXPECT_TRUE(response.status() == 200u ||
-              (response.status() >= 300 && response.status() < 400));
-}
-
-
-typedef boost::network::http::basic_client<boost::network::http::tags::http_async_8bit_tcp_resolve, 1, 1> async_client;
-#define EXC_PTR(cmd) try { cmd } catch (const std::exception_ptr& ex) { std::rethrow_exception(ex); }
-
 TYPED_TEST(HTTPClientTest, GetRequestSNI) {
   using client = TypeParam;
   // need sni_hostname to be set
@@ -93,4 +69,24 @@ TYPED_TEST(HTTPClientTest, GetRequestSNI) {
     FAIL() << "Caught exception while retrieving body from GET request";
   }
 
+}
+
+#endif
+
+TYPED_TEST(HTTPClientTest, TemporaryClientObjectTest) {
+  using client = TypeParam;
+  typename client::request request("http://cpp-netlib.org/");
+  typename client::response response;
+  ASSERT_NO_THROW(response = client().get(request));
+  auto range = headers(response);
+  ASSERT_TRUE(!boost::empty(range));
+  try {
+    auto data = body(response);
+    std::cout << data;
+  } catch (...) {
+    FAIL() << "Caught exception while retrieving body from GET request";
+  }
+  EXPECT_EQ("HTTP/1.", response.version().substr(0, 7));
+  EXPECT_TRUE(response.status() == 200u ||
+              (response.status() >= 300 && response.status() < 400));
 }


### PR DESCRIPTION
Fix #775 

Give the ability to set a sni_hostname at the request level : 
Use it like this: 
```
request.sni_hostname(request.host());
```

If set, it will be send instead of `client_options.openssl_sni_hostname()`.

