### PR TITLE
Work around ambiguous true_type

### DIFF
--- a/libs/network/src/server_request_parsers_impl.cpp
+++ b/libs/network/src/server_request_parsers_impl.cpp
@@ -39,22 +39,20 @@ namespace http {
 void parse_version(
     std::string const& partial_parsed,
     std::tuple<std::uint8_t, std::uint8_t>& version_pair) {
-  using namespace boost::spirit::qi;
-  parse(partial_parsed.begin(), partial_parsed.end(),
-        (lit("HTTP/") >> ushort_ >> '.' >> ushort_), version_pair);
+  boost::spirit::qi::parse(partial_parsed.begin(), partial_parsed.end(),
+        (boost::spirit::qi::lit("HTTP/") >> boost::spirit::qi::ushort_ >> '.' >> boost::spirit::qi::ushort_), version_pair);
 }
 
 void parse_headers(
     std::string const& input, std::vector<request_header_narrow>& container) {
   u8_to_u32_iterator<std::string::const_iterator> begin = input.begin(),
                                                   end = input.end();
-  using namespace boost::spirit::qi;
-  typedef as<boost::spirit::traits::u32_string> as_u32_string;
-  parse(begin, end,
-        *(+((alnum | punct) - ':') >> lit(": ") >>
-          as_u32_string()[+((unicode::alnum | space | punct) - '\r' - '\n')] >>
-          lit("\r\n")) >>
-            lit("\r\n"),
+  typedef boost::spirit::qi::as<boost::spirit::traits::u32_string> as_u32_string;
+  boost::spirit::qi::parse(begin, end,
+        *(+((boost::spirit::qi::alnum | boost::spirit::qi::punct) - ':') >> boost::spirit::qi::lit(": ") >>
+          as_u32_string()[+((boost::spirit::qi::unicode::alnum | boost::spirit::qi::space | boost::spirit::qi::punct) - '\r' - '\n')] >>
+          boost::spirit::qi::lit("\r\n")) >>
+            boost::spirit::qi::lit("\r\n"),
         container);
 }
 


### PR DESCRIPTION
Visual Studio 2017 cannot decide if it is

  `boost::integral_constant<bool,true> boost::true_type`

or

  `boost::spirit::true_type`