### PR TITLE
Make compatible with boost::chrono

### DIFF
--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -179,7 +179,13 @@ struct http_async_connection
 
     auto self = this->shared_from_this();
     if (timeout_ > 0) {
+#if defined(BOOST_ASIO_HAS_STD_CHRONO)
       timer_.expires_from_now(std::chrono::seconds(timeout_));
+#elif defined(BOOST_ASIO_HAS_BOOST_CHRONO)
+      timer_.expires_from_now(boost::chrono::seconds(timeout_));
+#else
+#error Need a chrono implementation
+#endif
       timer_.async_wait(request_strand_.wrap([=] (boost::system::error_code const &ec) {
             self->handle_timeout(ec);
           }));


### PR DESCRIPTION
In Visual Studio 2013 the `std::chrono` implementation is quite buggy. Therefore we fall back to `boost::chrono` by specifying `-DBOOST_ASIO_DISABLE_STD_CHRONO`. This change makes cppnetlib compatible with that flag.