### PR TITLE
Make compatible with boost::chrono

### DIFF
--- a/boost/network/protocol/http/client/connection/sync_normal.hpp
+++ b/boost/network/protocol/http/client/connection/sync_normal.hpp
@@ -77,7 +77,13 @@ struct http_sync_connection
       }
     }
     if (timeout_ > 0) {
+#if defined(BOOST_ASIO_HAS_STD_CHRONO)
       timer_.expires_from_now(std::chrono::seconds(timeout_));
+#elif defined(BOOST_ASIO_HAS_BOOST_CHRONO)
+      timer_.expires_from_now(boost::chrono::seconds(timeout_));
+#else
+#error Need a chrono implementation
+#endif
       auto self = this->shared_from_this();
       timer_.async_wait([=] (boost::system::error_code const &ec) {
           self->handle_timeout(ec);

--- a/boost/network/protocol/http/client/connection/sync_ssl.hpp
+++ b/boost/network/protocol/http/client/connection/sync_ssl.hpp
@@ -119,7 +119,13 @@ struct https_sync_connection
       }
     }
     if (timeout_ > 0) {
+#if defined(BOOST_ASIO_HAS_STD_CHRONO)
       timer_.expires_from_now(std::chrono::seconds(timeout_));
+#elif defined(BOOST_ASIO_HAS_BOOST_CHRONO)
+      timer_.expires_from_now(boost::chrono::seconds(timeout_));
+#else
+#error Need a chrono implementation
+#endif
       auto self = this->shared_from_this();
       timer_.async_wait(
           [=](boost::system::error_code const& ec) { self->handle_timeout(ec); });


### PR DESCRIPTION
(this fixes two more places that 702dd54353c missed)

Sorry, I missed those two places. Seems the code paths are not covered by tests or examples.