### PR TITLE
Do not wrap exceptions passed to boost::promise::set_exception in std…

### DIFF
--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -123,13 +123,13 @@ struct http_async_connection
  private:
   void set_errors(boost::system::error_code const& ec, body_callback_function_type callback) {
     boost::system::system_error error(ec);
-    this->version_promise.set_exception(std::make_exception_ptr(error));
-    this->status_promise.set_exception(std::make_exception_ptr(error));
-    this->status_message_promise.set_exception(std::make_exception_ptr(error));
-    this->headers_promise.set_exception(std::make_exception_ptr(error));
-    this->source_promise.set_exception(std::make_exception_ptr(error));
-    this->destination_promise.set_exception(std::make_exception_ptr(error));
-    this->body_promise.set_exception(std::make_exception_ptr(error));
+    this->version_promise.set_exception(error);
+    this->status_promise.set_exception(error);
+    this->status_message_promise.set_exception(error);
+    this->headers_promise.set_exception(error);
+    this->source_promise.set_exception(error);
+    this->destination_promise.set_exception(error);
+    this->body_promise.set_exception(error);
     if ( callback )
       callback( char_const_range(), ec );
     this->timer_.cancel();
@@ -456,28 +456,27 @@ struct http_async_connection
     } else {
       boost::system::error_code report_code = is_timedout_ ? boost::asio::error::timed_out : ec;
       boost::system::system_error error(report_code);
-      this->source_promise.set_exception(std::make_exception_ptr(error));
-      this->destination_promise.set_exception(std::make_exception_ptr(error));
+      this->source_promise.set_exception(error);
+      this->destination_promise.set_exception(error);
       switch (state) {
         case version:
-          this->version_promise.set_exception(std::make_exception_ptr(error));
+          this->version_promise.set_exception(error);
           // fall-through
         case status:
-          this->status_promise.set_exception(std::make_exception_ptr(error));
+          this->status_promise.set_exception(error);
           // fall-through
         case status_message:
-          this->status_message_promise.set_exception(
-              std::make_exception_ptr(error));
+          this->status_message_promise.set_exception(error);
           // fall-through
         case headers:
-          this->headers_promise.set_exception(std::make_exception_ptr(error));
+          this->headers_promise.set_exception(error);
           // fall-through
         case body:
           if (!callback) {
             // N.B. if callback is non-null, then body_promise has already been
             // set to value "" to indicate body is handled by streaming handler
             // so no exception should be set
-            this->body_promise.set_exception(std::make_exception_ptr(error));
+            this->body_promise.set_exception(error);
           }
           else
             callback( char_const_range(), report_code );

--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -128,13 +128,13 @@ struct http_async_protocol_handler {
                                        << "\"");
 #endif
       std::runtime_error error("Invalid Version Part.");
-      version_promise.set_exception(std::make_exception_ptr(error));
-      status_promise.set_exception(std::make_exception_ptr(error));
-      status_message_promise.set_exception(std::make_exception_ptr(error));
-      headers_promise.set_exception(std::make_exception_ptr(error));
-      source_promise.set_exception(std::make_exception_ptr(error));
-      destination_promise.set_exception(std::make_exception_ptr(error));
-      body_promise.set_exception(std::make_exception_ptr(error));
+      version_promise.set_exception(error);
+      status_promise.set_exception(error);
+      status_message_promise.set_exception(error);
+      headers_promise.set_exception(error);
+      source_promise.set_exception(error);
+      destination_promise.set_exception(error);
+      body_promise.set_exception(error);
     } else {
       partial_parsed.append(std::begin(result_range),
                             std::end(result_range));
@@ -175,12 +175,12 @@ struct http_async_protocol_handler {
                                        << "\"");
 #endif
       std::runtime_error error("Invalid status part.");
-      status_promise.set_exception(std::make_exception_ptr(error));
-      status_message_promise.set_exception(std::make_exception_ptr(error));
-      headers_promise.set_exception(std::make_exception_ptr(error));
-      source_promise.set_exception(std::make_exception_ptr(error));
-      destination_promise.set_exception(std::make_exception_ptr(error));
-      body_promise.set_exception(std::make_exception_ptr(error));
+      status_promise.set_exception(error);
+      status_message_promise.set_exception(error);
+      headers_promise.set_exception(error);
+      source_promise.set_exception(error);
+      destination_promise.set_exception(error);
+      body_promise.set_exception(error);
     } else {
       partial_parsed.append(std::begin(result_range),
                             std::end(result_range));
@@ -221,11 +221,11 @@ struct http_async_protocol_handler {
                                        << "\"");
 #endif
       std::runtime_error error("Invalid status message part.");
-      status_message_promise.set_exception(std::make_exception_ptr(error));
-      headers_promise.set_exception(std::make_exception_ptr(error));
-      source_promise.set_exception(std::make_exception_ptr(error));
-      destination_promise.set_exception(std::make_exception_ptr(error));
-      body_promise.set_exception(std::make_exception_ptr(error));
+      status_message_promise.set_exception(error);
+      headers_promise.set_exception(error);
+      source_promise.set_exception(error);
+      destination_promise.set_exception(error);
+      body_promise.set_exception(error);
     } else {
       partial_parsed.append(std::begin(result_range),
                             std::end(result_range));
@@ -323,10 +323,10 @@ struct http_async_protocol_handler {
                                        << boost::distance(result_range));
 #endif
       std::runtime_error error("Invalid header part.");
-      headers_promise.set_exception(std::make_exception_ptr(error));
-      body_promise.set_exception(std::make_exception_ptr(error));
-      source_promise.set_exception(std::make_exception_ptr(error));
-      destination_promise.set_exception(std::make_exception_ptr(error));
+      headers_promise.set_exception(error);
+      body_promise.set_exception(error);
+      source_promise.set_exception(error);
+      destination_promise.set_exception(error);
     } else {
       partial_parsed.append(std::begin(result_range),
                             std::end(result_range));

--- a/libs/network/test/http/client_get_test.cpp
+++ b/libs/network/test/http/client_get_test.cpp
@@ -55,7 +55,7 @@ TYPED_TEST(HTTPClientTest, GetRequestSNI) {
   // trying without setting sni_hostname
   ASSERT_NO_THROW(response = client().get(request));
   // raise "tlsv1 alert internal error"
-  ASSERT_THROW(response.status(), std::exception_ptr);
+  ASSERT_THROW(response.status(), boost::system::system_error);
 
   // setting sni_hostname
   request.sni_hostname(request.host());


### PR DESCRIPTION
…::exception_ptr (fixes #815)

boost::promise only knows about boost::exception_ptr, and handles
wrapping of concrete exception types into that itself. If passed
std::exception_ptr, it will wrap it a second time and later throw
the std::exception_ptr itself.