### PR TITLE
Switch from boost/thread/future.hpp to C++11 future.

### DIFF
--- a/boost/network/message/directives/detail/string_value.hpp
+++ b/boost/network/message/directives/detail/string_value.hpp
@@ -9,10 +9,10 @@
 #include <boost/network/traits/string.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_sync.hpp>
-#include <boost/thread/future.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/or.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -20,7 +20,7 @@ namespace detail {
 
 template <class Tag>
 struct string_value
-    : mpl::if_<is_async<Tag>, boost::shared_future<typename string<Tag>::type>,
+    : mpl::if_<is_async<Tag>, std::shared_future<typename string<Tag>::type>,
                typename mpl::if_<
                    mpl::or_<is_sync<Tag>, is_same<Tag, tags::default_string>,
                             is_same<Tag, tags::default_wstring> >,

--- a/boost/network/message/modifiers/clear_headers.hpp
+++ b/boost/network/message/modifiers/clear_headers.hpp
@@ -10,8 +10,9 @@
 #include <boost/mpl/not.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_pod.hpp>
-#include <boost/thread/future.hpp>
 #include <boost/utility/enable_if.hpp>
+
+#include <future>
 
 namespace boost {
 namespace network {
@@ -34,8 +35,8 @@ template <class Message, class Tag>
 inline typename enable_if<mpl::and_<mpl::not_<is_pod<Tag> >, is_async<Tag> >,
                           void>::type
 clear_headers(Message const &message, Tag const &) {
-  boost::promise<typename Message::headers_container_type> header_promise;
-  boost::shared_future<typename Message::headers_container_type> headers_future(
+  std::promise<typename Message::headers_container_type> header_promise;
+  std::shared_future<typename Message::headers_container_type> headers_future(
       header_promise.get_future());
   message.headers(headers_future);
   header_promise.set_value(typename Message::headers_container_type());

--- a/boost/network/message/traits/body.hpp
+++ b/boost/network/message/traits/body.hpp
@@ -13,8 +13,8 @@
 #include <boost/network/support/is_sync.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
-#include <boost/thread/future.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -27,7 +27,7 @@ template <class Message>
 struct body
     : mpl::if_<
           is_async<typename Message::tag>,
-          boost::shared_future<typename string<typename Message::tag>::type>,
+          std::shared_future<typename string<typename Message::tag>::type>,
           typename mpl::if_<
               mpl::or_<is_sync<typename Message::tag>,
                        is_same<typename Message::tag,

--- a/boost/network/message/traits/destination.hpp
+++ b/boost/network/message/traits/destination.hpp
@@ -12,8 +12,8 @@
 #include <boost/network/support/is_sync.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
-#include <boost/thread/future.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -26,7 +26,7 @@ struct unsupported_tag;
 template <class Message>
 struct destination
     : mpl::if_<is_async<typename Message::tag>,
-               boost::shared_future<typename string<typename Message::tag>::type>,
+               std::shared_future<typename string<typename Message::tag>::type>,
                typename mpl::if_<
                    mpl::or_<is_sync<typename Message::tag>,
                             is_same<typename Message::tag,

--- a/boost/network/message/traits/headers.hpp
+++ b/boost/network/message/traits/headers.hpp
@@ -14,7 +14,7 @@
 #include <boost/network/message/wrappers.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/support/is_sync.hpp>
-#include <boost/thread/future.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -28,7 +28,7 @@ template <class Message>
 struct header_key
     : mpl::if_<
           is_async<typename Message::tag>,
-          boost::shared_future<typename string<typename Message::tag>::type>,
+          std::shared_future<typename string<typename Message::tag>::type>,
           typename mpl::if_<
               mpl::or_<is_sync<typename Message::tag>,
                        is_same<typename Message::tag, tags::default_string>,
@@ -40,7 +40,7 @@ template <class Message>
 struct header_value
     : mpl::if_<
           is_async<typename Message::tag>,
-          boost::shared_future<typename string<typename Message::tag>::type>,
+          std::shared_future<typename string<typename Message::tag>::type>,
           typename mpl::if_<
               mpl::or_<is_sync<typename Message::tag>,
                        is_same<typename Message::tag, tags::default_string>,

--- a/boost/network/message/traits/source.hpp
+++ b/boost/network/message/traits/source.hpp
@@ -11,8 +11,8 @@
 #include <boost/network/support/is_sync.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
-#include <boost/thread/future.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -24,7 +24,7 @@ struct unsupported_tag;
 template <class Message>
 struct source
     : mpl::if_<is_async<typename Message::tag>,
-               boost::shared_future<typename string<typename Message::tag>::type>,
+               std::shared_future<typename string<typename Message::tag>::type>,
                typename mpl::if_<
                    mpl::or_<is_sync<typename Message::tag>,
                             is_same<typename Message::tag,

--- a/boost/network/protocol/http/client/connection/async_normal.hpp
+++ b/boost/network/protocol/http/client/connection/async_normal.hpp
@@ -203,13 +203,13 @@ struct http_async_connection
  private:
   void set_errors(boost::system::error_code const& ec, body_callback_function_type callback) {
     boost::system::system_error error(ec);
-    this->version_promise.set_exception(boost::copy_exception(error));
-    this->status_promise.set_exception(boost::copy_exception(error));
-    this->status_message_promise.set_exception(boost::copy_exception(error));
-    this->headers_promise.set_exception(boost::copy_exception(error));
-    this->source_promise.set_exception(boost::copy_exception(error));
-    this->destination_promise.set_exception(boost::copy_exception(error));
-    this->body_promise.set_exception(boost::copy_exception(error));
+    this->version_promise.set_exception(std::make_exception_ptr(error));
+    this->status_promise.set_exception(std::make_exception_ptr(error));
+    this->status_message_promise.set_exception(std::make_exception_ptr(error));
+    this->headers_promise.set_exception(std::make_exception_ptr(error));
+    this->source_promise.set_exception(std::make_exception_ptr(error));
+    this->destination_promise.set_exception(std::make_exception_ptr(error));
+    this->body_promise.set_exception(std::make_exception_ptr(error));
     if ( callback )
       callback( boost::iterator_range<typename std::array<typename char_<Tag>::type, 1024>::const_iterator>(), ec );
     this->timer_.cancel();

--- a/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
+++ b/boost/network/protocol/http/client/connection/async_protocol_handler.hpp
@@ -17,7 +17,7 @@
 #include <boost/network/protocol/http/parser/incremental.hpp>
 #include <boost/network/protocol/http/request_parser.hpp>
 #include <boost/network/traits/string.hpp>
-#include <boost/thread/future.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -58,30 +58,30 @@ struct http_async_protocol_handler {
     // TODO(dberris): review parameter necessity.
     (void)get_body;
 
-    boost::shared_future<string_type> source_future(
+    std::shared_future<string_type> source_future(
         source_promise.get_future());
     source(response_, source_future);
 
-    boost::shared_future<string_type> destination_future(
+    std::shared_future<string_type> destination_future(
         destination_promise.get_future());
     destination(response_, destination_future);
 
-    boost::shared_future<typename headers_container<Tag>::type> headers_future(
+    std::shared_future<typename headers_container<Tag>::type> headers_future(
         headers_promise.get_future());
     headers(response_, headers_future);
 
-    boost::shared_future<string_type> body_future(body_promise.get_future());
+    std::shared_future<string_type> body_future(body_promise.get_future());
     body(response_, body_future);
 
-    boost::shared_future<string_type> version_future(
+    std::shared_future<string_type> version_future(
         version_promise.get_future());
     version(response_, version_future);
 
-    boost::shared_future<std::uint16_t> status_future(
+    std::shared_future<std::uint16_t> status_future(
         status_promise.get_future());
     status(response_, status_future);
 
-    boost::shared_future<string_type> status_message_future(
+    std::shared_future<string_type> status_message_future(
         status_message_promise.get_future());
     status_message(response_, status_message_future);
   }
@@ -401,13 +401,13 @@ struct http_async_protocol_handler {
   typedef std::array<typename char_<Tag>::type, 1024> buffer_type;
 
   response_parser_type response_parser_;
-  boost::promise<string_type> version_promise;
-  boost::promise<std::uint16_t> status_promise;
-  boost::promise<string_type> status_message_promise;
-  boost::promise<typename headers_container<Tag>::type> headers_promise;
-  boost::promise<string_type> source_promise;
-  boost::promise<string_type> destination_promise;
-  boost::promise<string_type> body_promise;
+  std::promise<string_type> version_promise;
+  std::promise<std::uint16_t> status_promise;
+  std::promise<string_type> status_message_promise;
+  std::promise<typename headers_container<Tag>::type> headers_promise;
+  std::promise<string_type> source_promise;
+  std::promise<string_type> destination_promise;
+  std::promise<string_type> body_promise;
   buffer_type part;
   typename buffer_type::const_iterator part_begin;
   string_type partial_parsed;

--- a/boost/network/protocol/http/message/async_message.hpp
+++ b/boost/network/protocol/http/message/async_message.hpp
@@ -14,7 +14,7 @@
 
 // FIXME move this out to a trait
 #include <boost/network/detail/wrapper_base.hpp>
-#include <boost/thread/future.hpp>
+#include <future>
 #include <set>
 
 namespace boost {
@@ -55,63 +55,51 @@ struct async_message {
 
   string_type status_message() const {
     status_message_.wait();
-    if (status_message_.has_exception())
-      boost::rethrow_exception(status_message_.get_exception_ptr());
     return status_message_.get();
   }
 
-  void status_message(boost::shared_future<string_type> const& future) const {
+  void status_message(std::shared_future<string_type> const& future) const {
     status_message_ = future;
   }
 
   string_type version() const {
     version_.wait();
-    if (version_.has_exception())
-      boost::rethrow_exception(version_.get_exception_ptr());
     return version_.get();
   }
 
-  void version(boost::shared_future<string_type> const& future) const {
+  void version(std::shared_future<string_type> const& future) const {
     version_ = future;
   }
 
   std::uint16_t status() const {
     status_.wait();
-    if (status_.has_exception())
-      boost::rethrow_exception(status_.get_exception_ptr());
     return status_.get();
   }
 
-  void status(boost::shared_future<uint16_t> const& future) const {
+  void status(std::shared_future<uint16_t> const& future) const {
     status_ = future;
   }
 
   string_type source() const {
     source_.wait();
-    if (source_.has_exception())
-      boost::rethrow_exception(source_.get_exception_ptr());
     return source_.get();
   }
 
-  void source(boost::shared_future<string_type> const& future) const {
+  void source(std::shared_future<string_type> const& future) const {
     source_ = future;
   }
 
   string_type destination() const {
     destination_.wait();
-    if (destination_.has_exception())
-      boost::rethrow_exception(source_.get_exception_ptr());
     return destination_.get();
   }
 
-  void destination(boost::shared_future<string_type> const& future) const {
+  void destination(std::shared_future<string_type> const& future) const {
     destination_ = future;
   }
 
   headers_container_type const& headers() const {
     if (retrieved_headers_) return *retrieved_headers_;
-    if (headers_.has_exception())
-      boost::rethrow_exception(headers_.get_exception_ptr());
     headers_container_type raw_headers = headers_.get();
     raw_headers.insert(added_headers.begin(), added_headers.end());
     for (string_type const& key : removed_headers) {
@@ -121,8 +109,7 @@ struct async_message {
     return *retrieved_headers_;
   }
 
-  void headers(
-      boost::shared_future<headers_container_type> const& future) const {
+  void headers(std::shared_future<headers_container_type> const& future) const {
     headers_ = future;
   }
 
@@ -138,12 +125,10 @@ struct async_message {
 
   string_type body() const {
     body_.wait();
-    if (body_.has_exception())
-      boost::rethrow_exception(body_.get_exception_ptr());
     return body_.get();
   }
 
-  void body(boost::shared_future<string_type> const& future) const {
+  void body(std::shared_future<string_type> const& future) const {
     body_ = future;
   }
 
@@ -163,13 +148,13 @@ struct async_message {
   }
 
  private:
-  mutable boost::shared_future<string_type> status_message_, version_, source_,
+  mutable std::shared_future<string_type> status_message_, version_, source_,
       destination_;
-  mutable boost::shared_future<std::uint16_t> status_;
-  mutable boost::shared_future<headers_container_type> headers_;
+  mutable std::shared_future<std::uint16_t> status_;
+  mutable std::shared_future<headers_container_type> headers_;
   mutable headers_container_type added_headers;
   mutable std::set<string_type> removed_headers;
-  mutable boost::shared_future<string_type> body_;
+  mutable std::shared_future<string_type> body_;
   mutable boost::optional<headers_container_type> retrieved_headers_;
 
   friend struct boost::network::http::impl::ready_wrapper<Tag>;

--- a/boost/network/protocol/http/message/directives/status.hpp
+++ b/boost/network/protocol/http/message/directives/status.hpp
@@ -11,10 +11,10 @@
 #include <boost/mpl/if.hpp>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/tags.hpp>
-#include <boost/thread/future.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -25,18 +25,18 @@ struct basic_response;
 
 struct status_directive {
 
-  boost::variant<std::uint16_t, boost::shared_future<std::uint16_t> >
+  boost::variant<std::uint16_t, std::shared_future<std::uint16_t> >
       status_;
 
   explicit status_directive(std::uint16_t status) : status_(status) {}
 
-  explicit status_directive(boost::shared_future<std::uint16_t> const &status)
+  explicit status_directive(std::shared_future<std::uint16_t> const &status)
       : status_(status) {}
 
   status_directive(status_directive const &other) : status_(other.status_) {}
 
   template <class Tag>
-  struct value : mpl::if_<is_async<Tag>, boost::shared_future<std::uint16_t>,
+  struct value : mpl::if_<is_async<Tag>, std::shared_future<std::uint16_t>,
                           std::uint16_t> {};
 
   template <class Tag>

--- a/boost/network/protocol/http/message/traits/status.hpp
+++ b/boost/network/protocol/http/message/traits/status.hpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/tags.hpp>
-#include <boost/thread/future.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -24,7 +24,7 @@ template <class Message>
 struct status
     : mpl::if_<
           is_async<typename Message::tag>,
-          boost::shared_future<std::uint16_t>,
+          std::shared_future<std::uint16_t>,
           typename mpl::if_<is_sync<typename Message::tag>, std::uint16_t,
                             unsupported_tag<typename Message::tag> >::type> {};
 

--- a/boost/network/protocol/http/message/traits/status_message.hpp
+++ b/boost/network/protocol/http/message/traits/status_message.hpp
@@ -10,7 +10,7 @@
 #include <boost/network/support/is_async.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
-#include <boost/thread/future.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -25,7 +25,7 @@ template <class Message>
 struct status_message
     : mpl::if_<
           is_async<typename Message::tag>,
-          boost::shared_future<typename string<typename Message::tag>::type>,
+          std::shared_future<typename string<typename Message::tag>::type>,
           typename mpl::if_<
               mpl::or_<is_sync<typename Message::tag>,
                        is_same<typename Message::tag, boost::network::tags::default_string>,

--- a/boost/network/protocol/http/message/traits/version.hpp
+++ b/boost/network/protocol/http/message/traits/version.hpp
@@ -11,7 +11,7 @@
 #include <boost/network/support/is_sync.hpp>
 #include <boost/network/tags.hpp>
 #include <boost/network/traits/string.hpp>
-#include <boost/thread/future.hpp>
+#include <future>
 
 namespace boost {
 namespace network {
@@ -30,7 +30,7 @@ struct version {
 template <class Message>
 struct version<Message,
                typename enable_if<is_async<typename Message::tag> >::type> {
-  typedef boost::shared_future<typename string<typename Message::tag>::type>
+  typedef std::shared_future<typename string<typename Message::tag>::type>
       type;
 };
 


### PR DESCRIPTION
This fixes bugs with rethrown exceptions (e.g., avoids `std::exception_ptr` being thrown).