### PR TITLE
Directives: remove parens to silence gcc8 warning

### DIFF
--- a/boost/network/message/directives/detail/string_directive.hpp
+++ b/boost/network/message/directives/detail/string_directive.hpp
@@ -34,8 +34,8 @@
 #define BOOST_NETWORK_STRING_DIRECTIVE(name, value, body, pod_body)         \
   template <class ValueType>                                                \
   struct name##_directive {                                                 \
-    ValueType const&((value));                                              \
-    explicit name##_directive(ValueType const& value_) : value(value_) {}   \
+    ValueType const& value;                                              \
+    explicit name##_directive(ValueType const& v) : value(v) {}   \
     name##_directive(name##_directive const& other) : value(other.value) {} \
     template <class Tag, template <class> class Message>                    \
     typename enable_if<is_pod<Tag>, void>::type operator()(                 \


### PR DESCRIPTION
Fixes `-Wparentheses` warning from gcc8 builds.

Example build output:
```
cpp-netlib/boost/network/protocol/http/message/directives/status_message.hpp:17:1: note: in expansion of macro 'BOO
ST_NETWORK_STRING_DIRECTIVE'                                                                                                                
 BOOST_NETWORK_STRING_DIRECTIVE(status_message, status_message_,                                                                            
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                             
cpp-netlib/boost/network/message/directives/detail/string_directive.hpp:37:21: warning: unnecessary parentheses in 
declaration of 'uri_' [-Wparentheses]                                                                                                       
     ValueType const&((value));
```