### PR TITLE
Fix compile error with boost 1.71.0

### DIFF
--- a/boost/network/protocol/stream_handler.hpp
+++ b/boost/network/protocol/stream_handler.hpp
@@ -19,7 +19,6 @@
 #include <boost/asio/detail/throw_error.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/asio/io_service.hpp>
-#include <boost/asio/stream_socket_service.hpp>
 #include <cstddef>
 
 #ifdef BOOST_NETWORK_ENABLE_HTTPS


### PR DESCRIPTION
boost/network/protocol/stream_handler.hpp:22:48: fatal error: boost/asio/stream_socket_service.hpp: No such file or directory