### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,19 @@ you can now build the tests and run them::
     $ make
     $ make test
 
+You can also download and install cpp-netlib using the ` vcpkg`_ dependency manager:
+    
+    $ git clone https://github.com/Microsoft/vcpkg.git
+    $ cd vcpkg
+    $ ./bootstrap-vcpkg.sh
+    $ ./vcpkg integrate install
+    $ vcpkg install cpp-netlib
+    
+The cpp-netlib port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request on the ` vcpkg`_ repository.
+
+.. _`vcpkg`: https://github.com/Microsoft/vcpkg
+
+
 If for some reason some of the tests fail, you can send the files in
 ``Testing/Temporary/`` as attachments to the cpp-netlib `developers mailing
 list`_.


### PR DESCRIPTION
`cpp-netlib` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `cpp-netlib` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `cpp-netlib`, ready to be included in their projects.

We also test whether our library ports build in static configurations on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/cpp-netlib/portfile.cmake). We try to keep the library maintained as close as possible to the original library.