### PR TITLE
Add clear resolved cache

### DIFF
--- a/boost/network/protocol/http/policies/async_resolver.hpp
+++ b/boost/network/protocol/http/policies/async_resolver.hpp
@@ -36,18 +36,21 @@ struct async_resolver : std::enable_shared_from_this<async_resolver<Tag> > {
   typedef std::function<void(resolver_type &, string_type, std::uint16_t,
                              resolve_completion_function)> resolve_function;
 
+  void clear_resolved_cache() { clear_cache_ = true; }
+
  protected:
   bool cache_resolved_;
+  bool clear_cache_;
   endpoint_cache endpoint_cache_;
   std::shared_ptr<boost::asio::io_service> service_;
   std::shared_ptr<boost::asio::io_service::strand> resolver_strand_;
 
   explicit async_resolver(bool cache_resolved)
-      : cache_resolved_(cache_resolved), endpoint_cache_() {}
+      : cache_resolved_(cache_resolved), endpoint_cache_(), clear_cache_(false) {}
 
   void resolve(resolver_type &resolver_, string_type const &host,
                std::uint16_t port, resolve_completion_function once_resolved) {
-    if (cache_resolved_) {
+    if (cache_resolved_ && !clear_cache_) {
       typename endpoint_cache::iterator iter =
           endpoint_cache_.find(boost::to_lower_copy(host));
       if (iter != endpoint_cache_.end()) {
@@ -74,6 +77,10 @@ struct async_resolver : std::enable_shared_from_this<async_resolver<Tag> > {
     typename endpoint_cache::iterator iter;
     bool inserted = false;
     if (!ec && cache_resolved_) {
+      if (clear_cache_) {
+        clear_cache_ = false;
+        endpoint_cache_.clear();
+      }
       std::tie(iter, inserted) = endpoint_cache_.insert(std::make_pair(
           host, std::make_pair(endpoint_iterator, resolver_iterator())));
       once_resolved(ec, iter->second);

--- a/boost/network/protocol/http/policies/sync_resolver.hpp
+++ b/boost/network/protocol/http/policies/sync_resolver.hpp
@@ -27,19 +27,27 @@ struct sync_resolver {
   typedef std::pair<resolver_iterator, resolver_iterator>
       resolver_iterator_pair;
 
+  void clear_resolved_cache() { clear_cache_ = true; }
+
  protected:
   typedef typename string<Tag>::type string_type;
   typedef std::unordered_map<string_type, resolver_iterator_pair>
       resolved_cache;
   resolved_cache endpoint_cache_;
   bool cache_resolved_;
+  bool clear_cache_;
 
-  explicit sync_resolver(bool cache_resolved) : cache_resolved_(cache_resolved) {}
+  explicit sync_resolver(bool cache_resolved)
+      : cache_resolved_(cache_resolved), clear_cache_(false) {}
 
   resolver_iterator_pair resolve(resolver_type& resolver_,
                                  string_type  /*unused*/const& hostname,
                                  string_type const& port) {
     if (cache_resolved_) {
+      if (clear_cache_) {
+        clear_cache_ = false;
+        endpoint_cache_.clear();
+	  }
       typename resolved_cache::iterator cached_iterator =
           endpoint_cache_.find(hostname);
       if (cached_iterator == endpoint_cache_.end()) {


### PR DESCRIPTION
`basic_client_facade` write a `clear_resolved_cache()` but no functions are implemented with pimpl. Add implementation for async_resolver and sync_resolver.