### PR TITLE
Fixup asio old service removed after boost 1.69

### DIFF
--- a/boost/network/protocol/stream_handler.hpp
+++ b/boost/network/protocol/stream_handler.hpp
@@ -13,12 +13,12 @@
 #include <memory>
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/basic_socket.hpp>
+#include <boost/asio/basic_stream_socket.hpp>
 #include <boost/asio/detail/config.hpp>
 #include <boost/asio/detail/handler_type_requirements.hpp>
 #include <boost/asio/detail/push_options.hpp>
 #include <boost/asio/detail/throw_error.hpp>
 #include <boost/asio/error.hpp>
-#include <boost/asio/stream_socket_service.hpp>
 #include <cstddef>
 
 #ifdef BOOST_NETWORK_ENABLE_HTTPS


### PR DESCRIPTION
BOOST_ASIO_ENABLE_OLD_SERVICES option and all those header files are removed from boost asio 1.70.